### PR TITLE
Claude Code integration + offline test suite, coverage, and serialization snapshot

### DIFF
--- a/.claude/agents/csharp-build-reviewer.md
+++ b/.claude/agents/csharp-build-reviewer.md
@@ -1,0 +1,36 @@
+---
+name: csharp-build-reviewer
+description: Reviews changed C# in the Transloadit Sharp repo against its strict build and convention rules before it hits CI. Use after adding or editing library code (robots, credentials, services, models) — especially via the add-robot / add-credentials / add-service-endpoint skills — to catch missing XML docs, nullable-annotation slips, framework-incompatible APIs, and convention breaks that would fail the build.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+# C# build reviewer (Transloadit Sharp)
+
+You review changed C# in this repository against the constraints that make its build fail or break conventions. This build is strict: `TreatWarningsAsErrors` is on and `GenerateDocumentationFile` is on, so *any* warning — including a missing XML doc — fails compilation. You are read-only: report findings, do not edit.
+
+## Scope
+
+Review the changed/added `.cs` files (use `git diff --stat` and `git diff` to find them). For each, check the list below.
+
+## Checklist
+
+1. **XML docs on every public API.** Every `public` type, method, property, constructor, and field needs a `///` doc comment. A missing one is a build error here, not a warning. Also check `<param>`/`<returns>` on public methods.
+2. **No nullable reference annotations.** `Nullable` is disabled — flag any `string?`, `object?`, or other nullable *reference* type. `?` is allowed only on value types (`int?`, `bool?`, `DateTime?`).
+3. **Old-framework compatibility.** The library targets down to `net452` / `netstandard2.0`. Flag BCL APIs that don't exist on those targets (e.g. newer `System.*` methods, range/index operators on unsupported types); suggest a bridge in `src/Transloadit/Polyfills/` instead. `LangVersion` is 12, so C# 12 *syntax* is fine — the risk is *runtime APIs*, not language features.
+4. **Async conventions.** Public awaitable methods end in `Async` and every `await` uses `.ConfigureAwait(false)`.
+5. **JSON mapping.** Serialized properties carry `[JsonProperty("snake_case_key")]` matching the Transloadit API; enum-like string values come from a `src/Transloadit/Constants/` class rather than raw string literals.
+6. **Comment style.** Prose comments start with a lowercase letter and have no trailing period; type/method/property names in doc prose are wrapped in `<c>`/`<see cref>` where appropriate.
+7. **Robot-specific** (files under `Models/Robots/`): the `Robot` string is set in the constructor; the docs link appears in both the class `<summary>` and the constructor `<summary>`; a `Assert.Equal("/x/y", new <Name>Robot().Robot);` assertion was added to `tests/Transloadit.Tests/Tests/NewRobotsTests.cs`.
+
+## Optional build check
+
+When useful, actually compile and report the exact warnings/errors:
+
+```sh
+dotnet build src/Transloadit/Transloadit.csproj -c Release
+```
+
+## Output
+
+Return a concise findings list grouped by file, each item: `file:line` — the issue — the specific fix. Note whether a finding is a hard build failure (missing doc, `string?`, incompatible API) or a convention break. If a build was run, include its pass/fail result. Do not modify any files.

--- a/.claude/agents/docs-coverage-auditor.md
+++ b/.claude/agents/docs-coverage-auditor.md
@@ -1,0 +1,58 @@
+---
+name: docs-coverage-auditor
+description: Audits drift between the Transloadit docs and the Transloadit Sharp C# library, and reports the differences. Use when the user wants to know which robots/credentials/endpoints the docs describe but the code is missing (or has gone stale/renamed upstream), or wants a per-robot parameter-coverage check. Returns a ranked, actionable diff report — it does not edit code.
+---
+
+# Docs ↔ code coverage auditor
+
+You compare what Transloadit documents against what this library implements, and report the gaps. You are read-only: produce a report, suggest fixes (e.g. "run the add-robot skill for /x/y"), but do not edit files.
+
+The authoritative docs source is Transloadit's machine-readable dump (see the `fetch-transloadit-docs` skill for the format): `https://transloadit.com/llms.txt` is the robot index, `https://transloadit.com/llms-full.txt` holds each robot's Zod schema. Download both with `curl` to your scratch dir once; `WebFetch` truncates the large file.
+
+## 1. Robot coverage (primary)
+
+**Docs set** — extract every robot path from the index:
+```sh
+curl -sSL https://transloadit.com/llms.txt -o "$SCRATCH/llms.txt"
+grep -oE '\[(/[a-z0-9]+/[a-z0-9]+)\]' "$SCRATCH/llms.txt" | tr -d '[]' | sort -u > "$SCRATCH/docs_robots.txt"
+```
+
+**Code set** — every robot is a ctor assignment `Robot = "/x/y";`:
+```sh
+grep -rhoE 'Robot = "(/[^"]+)"' src/Transloadit/Models/Robots/ \
+  | grep -oE '/[^"]+' | sort -u > "$SCRATCH/code_robots.txt"
+```
+
+**Diff:**
+```sh
+comm -23 "$SCRATCH/docs_robots.txt" "$SCRATCH/code_robots.txt"   # documented but NOT implemented → add these
+comm -13 "$SCRATCH/docs_robots.txt" "$SCRATCH/code_robots.txt"   # implemented but NOT in docs → deprecated/renamed/typo?
+```
+
+For each **missing** robot, pull its one-line description from `llms.txt` and infer the target category folder.
+For each **stale-in-code** robot, check whether it was renamed upstream (search `llms-full.txt` for a similar path) versus genuinely removed.
+
+## 2. Per-robot parameter drift (deep mode — when asked, or for robots the user names)
+
+For a robot present in both sides:
+- **Docs params:** find the robot's Zod block (`grep -n "\[/x/y docs\]" llms-full.txt`, then read from that line to the next `[/… docs]` anchor). The parameters are the **top-level keys** of the `z.object({ … })` — the identifiers at the object's first indent level, each followed by `: z…` or `: XxxSchema`. Read the block with judgment; do not trust a flat regex (description text and nested-object keys will pollute it).
+- **Code params:** `grep -rhoE 'JsonProperty\("[a-z_]+"\)' <the robot's .cs file(s)>`.
+- **Exclude base-class params** (they live on `RobotBase`/`ImportRobotBase`/`StoreRobotBase`/`PaginatedImportRobotBase` and appear in every schema): `robot`, `result`, `force_accept`, `use`, `ignore_errors`, `credentials`, `path`, `output_meta`, `queue`, `interpolate`.
+- Report: keys in docs but not in code (**missing properties**) and keys in code but not in docs (**possibly removed/renamed upstream**).
+
+## 3. Credentials & endpoints (optional, if asked)
+
+- **Credentials:** docs credential services vs code discriminators `grep -rhoE 'Type = "[^"]+"' src/Transloadit/Models/Credentials/`.
+- **Endpoints:** compare the API reference under `https://transloadit.com/docs/api/` against the methods on `src/Transloadit/Services/*Service.cs`. This is coarser — flag obvious whole-endpoint gaps rather than field-level drift.
+
+## Output
+
+Return a concise, ranked report — not file dumps:
+
+- **Summary:** `N documented robots, M implemented, K missing, S stale`.
+- **Missing in code** (highest priority): bulleted `/x/y — <one-line docs description> — suggested folder <Category>`. Note these can be added with the `add-robot` skill.
+- **In code, not in docs:** list with a short hypothesis (renamed? deprecated? typo in the `Robot` string?).
+- **Parameter drift** (only if run): per robot, the missing/extra keys.
+- If everything matches, say so plainly.
+
+Keep it scannable. Do not modify any files.

--- a/.claude/skills/add-credentials/SKILL.md
+++ b/.claude/skills/add-credentials/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: add-credentials
+description: Add a new template-credentials type to the Transloadit Sharp library (e.g. S3, Azure, FTP, Supabase). Use when the user wants to support storing credentials for a new service. Handles the Request + Content class pair, the Type string, and why no service change is needed.
+---
+
+# Add a template-credentials type
+
+Credentials request models live in `src/Transloadit/Models/Credentials/`. `CredentialsService.CreateAsync` / `UpdateAsync` accept the abstract base `CredentialsRequestBase`, so a new type is fully polymorphic — **no service or client change is required**.
+
+## Steps
+
+1. **Fetch the content fields** for the service using the `fetch-transloadit-docs` skill (API credentials docs). Cross-check against an existing sibling such as `S3CredentialsRequest.cs` or `AzureCredentialsRequest.cs`.
+
+2. **Create** `src/Transloadit/Models/Credentials/<Svc>CredentialsRequest.cs` with two `public` classes in one file:
+   - `public class <Svc>CredentialsRequest : CredentialsRequestBase` (base in `CredentialsRequest.cs`; it provides `[JsonProperty("name")] Name`). The parameterless constructor sets the discriminator:
+     ```csharp
+     public <Svc>CredentialsRequest()
+     {
+         Type = "<svc>";
+     }
+     ```
+     and exposes `[JsonProperty("content")] public <Svc>CredentialsContent Content { get; set; }`.
+   - `public class <Svc>CredentialsContent` holding the service fields, each with `[JsonProperty("snake_case_key")]`.
+
+3. **Conventions:** nullable value types use `?`; no `string?` (`Nullable` is disabled); full XML docs on every public type and member (build fails otherwise); comments lowercase, no trailing period.
+
+4. **Verify:** `dotnet build src/Transloadit/Transloadit.csproj -c Release`.
+
+5. **Tests (optional).** `tests/Transloadit.Tests/Tests/Api/CredentialsApiTests.cs` runs a live create→get→update→list→delete lifecycle and needs real credentials in `appsettings.Tests.json`; extend it only if you have credentials to run against. A serialization unit test (asserting `Type`/JSON keys) needs no credentials and is a good lightweight alternative.

--- a/.claude/skills/add-robot/SKILL.md
+++ b/.claude/skills/add-robot/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: add-robot
+description: Add a new Transloadit Robot model class to the Transloadit Sharp library. Use when the user wants to implement/add a robot, gives a robot path like /image/resize or /ai/chat, or points at a robot docs URL. Handles picking the base class, the constructor Robot string, snake_case JsonProperty mapping, mandatory XML docs, and the NewRobotsTests assertion.
+---
+
+# Add a Transloadit Robot
+
+Robots are strongly-typed step models under `src/Transloadit/Models/Robots/<Category>/`. There is **no central registry** — a robot is consumed polymorphically via `Dictionary<string, RobotBase>` on `AssemblyRequest.Steps` and `TemplateRequestContent.Steps`, so adding one means adding a single class file plus a test assertion. Nothing else references it.
+
+## Steps
+
+1. **Resolve slug + category.** From the robot path `/x/y`, derive the docs slug (`/image/resize` → `image-resize`) and map the Transloadit doc category to an existing folder:
+   `AI`, `AudioEncoding`, `Code`, `Documents`, `FileCompressing`, `FileExporting`, `FileFiltering`, `FileImporting`, `ImageManipulation`, `MediaCataloging`, `SmartCdn`, `VideoEncoding`.
+
+2. **Fetch the parameter spec** using the `fetch-transloadit-docs` skill.
+
+3. **Open a sibling** in the same category folder and mirror it — it is the source of truth for idioms. Pick the base class from `src/Transloadit/Models/Robots/RobotBase.cs`:
+   - `RobotBase` — default.
+   - `ImportRobotBase` / `PaginatedImportRobotBase` — import robots (add `ignore_errors`, `credentials`, `path`, and pagination).
+   - `StoreRobotBase` — store/export robots (add `use`, `credentials`, `path`).
+   - If a base's fields don't quite fit, derive `RobotBase` directly and declare the fields yourself (some existing import robots do this).
+
+4. **Create the file** `src/Transloadit/Models/Robots/<Category>/<Name>Robot.cs`:
+   - namespace `Transloadit.Models.Robots.<Category>`
+   - `public class <Name>Robot : <Base>`
+   - parameterless constructor sets the path: `Robot = "/x/y";`
+
+5. **Map each parameter** to a `public` property:
+   - `[JsonProperty("snake_case_key")]` on every property.
+   - nullable value types use `?` (`int?`, `bool?`, `double?`); reference types plain — do **not** write `string?` (`Nullable` is disabled).
+   - multi-shape fields → `AnyOf<...>` (`src/Transloadit/Models/AnyOf.cs`).
+   - enum-like string values → reuse or add a `src/Transloadit/Constants/` static class and reference it in the doc with `<see cref="Constants.X"/>`.
+
+6. **Write XML docs on everything** — the build has `TreatWarningsAsErrors` + `GenerateDocumentationFile`, so a missing `///` fails compilation:
+   - class `<summary>`: `Represents <a href="https://transloadit.com/docs/robots/<slug>/">/x/y</a> Robot.`
+   - constructor `<summary>`: `Initializes <a href="https://transloadit.com/docs/robots/<slug>/">/x/y</a> Robot.`
+   - every property: describe it; use `<para>Default: <c>...</c></para>`, `<c>` for values, `<list>`/`<item>` for enumerations, matching the siblings.
+   - comments in prose start lowercase, no trailing period.
+
+7. **Nested models** (robot-specific sub-objects) go in the same file, `public`, fully doc-commented.
+
+8. **Add the test assertion** to `tests/Transloadit.Tests/Tests/NewRobotsTests.cs` — this is the canonical place robots are enumerated:
+   ```csharp
+   Assert.Equal("/x/y", new <Name>Robot().Robot);
+   ```
+   Add assertions for any new `Constants` values too.
+
+9. **Verify:**
+   ```sh
+   dotnet build src/Transloadit/Transloadit.csproj -c Release
+   dotnet test tests/Transloadit.Tests/Transloadit.Tests.csproj -f net8.0 --filter "FullyQualifiedName~NewRobotsTests"
+   ```
+   Optionally hand the diff to the `csharp-build-reviewer` agent.

--- a/.claude/skills/add-service-endpoint/SKILL.md
+++ b/.claude/skills/add-service-endpoint/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: add-service-endpoint
+description: Add a new API endpoint method to an existing Transloadit Sharp service, or add a whole new service area. Use when the user wants to call a Transloadit API endpoint the library doesn't cover yet. Handles the SendRequest delegation, request/response models, signature-auth toggling, and the lazy service property on TransloaditClient.
+---
+
+# Add a service endpoint (or a new service)
+
+Services live in `src/Transloadit/Services/` and are the typed wrappers over the single request choke point `TransloaditClient.SendRequest<T>` (`src/Transloadit/TransloaditClient.cs`). Each is registered as a lazy property on the client.
+
+## Fetch the spec
+
+Use `fetch-transloadit-docs` against the `/docs/api/` endpoint to get the path, HTTP method, request params, and response shape. Cross-check against an existing service (e.g. `CredentialsService.cs`, `TemplatesService.cs`) and its models.
+
+## Mode A — new endpoint on an existing service
+
+1. Add request/response models as needed:
+   - request: `public class <X>Request : BaseParams` (or `PaginationParams` for lists), snake_case `[JsonProperty]` fields.
+   - response: `public class <X>Response : ResponseBase`.
+2. Add the method to the service:
+   ```csharp
+   /// <summary>...</summary>
+   public async Task<<X>Response> <X>Async(<args>)
+   {
+       return await _client.SendRequest<<X>Response>(HttpMethod.<Verb>, $"/path/{id}", requestModel)
+           .ConfigureAwait(false);
+   }
+   ```
+   - `HttpMethod` maps to REST semantics (`Get`/`Post`/`Put`/`Delete`).
+   - for **unsigned** endpoints, disable signing on the params: `parameters.EnableSignatureAuth = false;` or `parameters.DisableSignatureAuth();` (pattern in `AssembliesService.GetAsync`).
+
+## Mode B — new service area
+
+1. Create `src/Transloadit/Services/<Area>Service.cs`:
+   ```csharp
+   public class <Area>Service
+   {
+       private readonly TransloaditClient _client;
+
+       /// <summary>...</summary>
+       public <Area>Service(TransloaditClient client) => _client = client;
+
+       // endpoint methods (Mode A)
+   }
+   ```
+2. Register a lazy property on `src/Transloadit/TransloaditClient.cs`, next to the existing ones:
+   ```csharp
+   private <Area>Service _<area>Service;
+   /// <summary><Area> service.</summary>
+   public <Area>Service <Area> => _<area>Service ??= new <Area>Service(this);
+   ```
+
+## Conventions & verify
+
+- `Async` suffix; `.ConfigureAwait(false)` on every await; full XML docs (build fails otherwise); nullable value types only (no `string?`); comments lowercase, no trailing period.
+- `dotnet build src/Transloadit/Transloadit.csproj -c Release`.
+- Add a `tests/Transloadit.Tests/Tests/Api/<Area>ApiTests.cs` integration test (derives from `TestBase`, needs live credentials) and/or a credential-free serialization unit test.

--- a/.claude/skills/coverage/SKILL.md
+++ b/.claude/skills/coverage/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: coverage
+description: Run the Transloadit Sharp test suite with code coverage and produce an AI-readable report. Use when the user wants a coverage report, asks "what's covered / what's untested", wants to raise coverage, or after adding tests to see the delta. Runs offline unit tests on net8.0, emits a Markdown/text summary you read to find the lowest-covered files, then act.
+---
+
+# Code coverage
+
+Produces a cobertura report from the test suite and a Markdown/text summary you can read to decide what to test next. Coverage runs on a **single modern TFM (net8.0)** — the project multi-targets, and running all TFMs would produce a report per framework.
+
+Use a scratch directory for output so nothing lands in the repo. In examples below `$OUT` is `<scratch>/coverage` (your session scratchpad).
+
+## Steps
+
+1. **Restore the report tool** (pinned in `.config/dotnet-tools.json`):
+   ```sh
+   dotnet tool restore
+   ```
+
+2. **Run tests with coverage.** To measure everything, run the whole suite — but the live `Tests/Api/*` and `AssemblyTrackerTests` need real credentials in `tests/Transloadit.Tests/appsettings.Tests.json`. If you don't have credentials, filter to the offline tests so the run is green:
+   ```sh
+   dotnet test tests/Transloadit.Tests/Transloadit.Tests.csproj -f net8.0 \
+     --collect:"XPlat Code Coverage" --settings coverlet.runsettings \
+     --results-directory "$OUT" \
+     --filter "FullyQualifiedName~Tests.Unit|FullyQualifiedName~Tests.Models|FullyQualifiedName~Tests.Constants|FullyQualifiedName~SignatureTests|FullyQualifiedName~SerializationDefaultsTests|FullyQualifiedName~NewRobotsTests"
+   ```
+   Drop the `--filter` to include the live integration tests when credentials are present (higher coverage of the service methods).
+
+3. **Generate the report.** The collector writes `coverage.cobertura.xml` under a per-run GUID folder:
+   ```sh
+   dotnet tool run reportgenerator \
+     -reports:"$OUT/**/coverage.cobertura.xml" \
+     -targetdir:"$OUT/report" \
+     -reporttypes:"MarkdownSummaryGithub;TextSummary;Html"
+   ```
+
+4. **Read the summary and act.** Read `$OUT/report/Summary.txt` (or `SummaryGithub.md`) — it lists line/branch coverage per class. Identify the lowest-covered types in `src/Transloadit`, open them, and add targeted tests (prefer the offline patterns in `tests/Transloadit.Tests/Tests/Unit/` and the reflection smoke tests in `Tests/Models/`). The HTML report (`$OUT/report/index.html`) is for humans.
+
+## Notes
+
+- The `.gitignore` already ignores `coverage*.xml`; keep coverage output in scratch so nothing is committed.
+- The runsettings (`coverlet.runsettings`) excludes the test assembly and generated code, so figures reflect `src/Transloadit` only.
+- Pure logic (signatures, converters, `AnyOf`, base params/responses, the client pipeline via the fake handler) and all robot/credential model serialization are covered offline; the numbers for service methods that only do a `SendRequest` round-trip rise further when the credentialed integration tests are included.

--- a/.claude/skills/fetch-transloadit-docs/SKILL.md
+++ b/.claude/skills/fetch-transloadit-docs/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: fetch-transloadit-docs
+description: Fetch the authoritative parameter spec for a Transloadit Robot or API endpoint from the official docs. Use when implementing or updating a robot/credentials/endpoint model and you need the exact parameters (names, types, defaults, allowed values), or whenever the user asks to "look up the params/docs for /x/y". Called by the add-robot, add-credentials, and add-service-endpoint skills.
+---
+
+# Fetch Transloadit docs
+
+Pull the authoritative parameter list for a Robot or API endpoint so a C# model maps exactly. The reliable source is Transloadit's machine-readable **`llms-full.txt`**, which contains a **Zod schema** for every robot — exact keys, types, defaults, and descriptions. The rendered HTML pages and per-robot `.md` pages are JS stubs that omit parameters, so do **not** rely on `WebFetch` against them.
+
+## Slug mapping
+
+A robot's Assembly path maps to a docs slug by dropping the leading slash and replacing slashes with hyphens: `/image/resize` → `image-resize`, `/ftp/import` → `ftp-import`.
+
+## Robots — primary method (curl + grep the Zod schema)
+
+1. Download the full dump once per session to your scratch dir (it is ~650 KB / ~13k lines; `WebFetch` truncates it, so use `curl`):
+   ```sh
+   curl -sSL https://transloadit.com/llms-full.txt -o "$SCRATCH/llms-full.txt"
+   ```
+2. Find the robot's section anchor (each of the ~95 robots has one `[/x/y docs](...)` line):
+   ```sh
+   grep -n "\[/image/resize docs\]" "$SCRATCH/llms-full.txt"
+   ```
+3. Read from that line to the **next** `[/… docs](https://transloadit.com/docs/robots/` anchor — that span is the robot's `const xxxSchema = z.object({ … })` block. Read it with the Read tool (offset/limit) rather than dumping the whole file.
+4. The robot index (slug + one-line description for every robot) is `https://transloadit.com/llms.txt` (~230 lines) — handy for confirming the exact path/slug.
+
+## Zod → C# mapping (how to read the schema)
+
+| Zod in `llms-full.txt` | C# in this repo |
+|---|---|
+| `z.string()` | `string` |
+| `z.number().int().gte(1).lte(25000)` | `int?` |
+| `z.number()` (non-int) | `double?` |
+| `z.boolean()` / `z.union([z.boolean(), z.enum(['true','false'])])` | `bool?` |
+| `z.enum(['a','b'])` / `.literal('x')` | `string` + add/reuse a `Constants/` class, `<see cref>` it |
+| `z.union([z.string(), z.array(z.string())])` | `AnyOf<string, List<string>>` |
+| `z.union([z.boolean(), z.object(...)])` | `AnyOf<bool, SomeModel>` |
+| `.describe('...')` | the property's `///` `<summary>` text |
+| `.default(x)` | note `<para>Default: <c>x</c></para>` |
+| `.optional()` / `.default(...)` | nullable value type (`?`); reference types stay plain (no `string?`) |
+
+Shared sub-schemas (`IgnoreErrorsSchema`, `UseSchema`, `OutputMetaSchema`, `ResultSchema`, `ForceAcceptSchema`) are already modeled on the base classes in `src/Transloadit/Models/Robots/RobotBase.cs` — don't re-declare them; pick the base class that provides them.
+
+## API endpoints
+
+For service endpoints, use the API markdown pages via `curl` (some are non-empty, some 404 depending on slug):
+```sh
+curl -sSL https://transloadit.com/docs/api/authentication.md
+```
+Discover the correct slug from the index at `https://transloadit.com/docs/api/`. The intro sections of `llms-full.txt` / `llms.txt` also describe Assembly Instructions and auth.
+
+## Cross-check (required)
+
+Reconcile the fetched spec against a **sibling class in the same folder** — it is the source of truth for this repo's idioms (`AnyOf<>`, `Constants/`, nullable value types, doc style). If docs and siblings disagree on a shape, follow the sibling and note the discrepancy to the user. Downloaded files are cached in scratch for the session; re-`curl` only if you suspect staleness.

--- a/.claude/skills/release-pack/SKILL.md
+++ b/.claude/skills/release-pack/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: release-pack
+description: Cut a NuGet release of the Transloadit Sharp library — bump the version, build and pack, and (only if asked) trigger the deploy workflow. Use when the user wants to release, publish to NuGet, pack the package, or bump the version.
+---
+
+# Release / pack
+
+The package version lives in `<Version>` in `src/Transloadit/Transloadit.csproj`. Publishing is done by the manual **NuGet Deploy** GitHub workflow (`.github/workflows/deploy.yml`), not from a dev machine.
+
+## Steps
+
+1. **Bump the version** — edit `<Version>` in `src/Transloadit/Transloadit.csproj` (e.g. `0.9.4` → `0.9.5`). Always bump *before* deploying; the workflow tags the commit `v<Version>` and only creates the tag if it doesn't already exist.
+
+2. **Build and pack locally to validate:**
+   ```sh
+   dotnet build src/Transloadit/Transloadit.csproj -c Release
+   dotnet pack src/Transloadit -c Release --output nuget
+   ```
+   This produces `nuget/Transloadit.<Version>.nupkg`.
+
+3. **Deploy (only when the user explicitly asks).** The workflow is `workflow_dispatch` and requires a `notifyUrl` input plus repo secrets (`AUTH_KEY`, `AUTH_SECRET`, `NUGET_KEY`); it runs the full test matrix, packs, tags `v<Version>`, and pushes to nuget.org. Do **not** commit, push, or trigger it on your own. When asked, trigger with:
+   ```sh
+   gh workflow run "NuGet Deploy" -f notifyUrl=<https url>
+   ```
+
+## Notes
+
+- Committing the version bump and triggering the deploy are outward-facing actions — confirm with the user first.
+- The deploy tests hit the live Transloadit API and are gated on the `Release` environment secrets; a local pack does not run them.

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.5.10",
+      "commands": [
+        "reportgenerator"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -97,6 +97,15 @@ dotnet_naming_symbols.constants.required_modifiers = const
 
 dotnet_naming_style.constant_style.capitalization = pascal_case
 
+# Static fields are PascalCase
+dotnet_naming_rule.static_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.static_fields_should_be_pascal_case.symbols = static_fields
+dotnet_naming_rule.static_fields_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_symbols.static_fields.applicable_kinds = field
+dotnet_naming_symbols.static_fields.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
 # Naming styles
 
 dotnet_naming_style.begins_with_i.required_prefix = I

--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ _TeamCity*
 coverage*.json
 coverage*.xml
 coverage*.info
+TestResults/
 
 # Visual Studio code coverage results
 *.coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Transloadit Sharp is a .NET client library for the [Transloadit](https://transloadit.com) API, published to NuGet as `Transloadit`. It is a portable class library targeting a wide range of frameworks — from `net452` and `netstandard2.0` through `net10.0`. The only runtime dependency is `Newtonsoft.Json`.
+
+## Build & Test
+
+The solution uses the `.slnx` format (`Transloadit.slnx`). Use the .NET CLI:
+
+```sh
+dotnet build Transloadit.slnx                                  # build all target frameworks
+dotnet build src/Transloadit/Transloadit.csproj -c Release     # build the library only
+dotnet pack src/Transloadit -c Release                         # produce the NuGet package
+```
+
+Tests are xUnit and live in `tests/Transloadit.Tests`. Run a single target framework (the test project multi-targets, so always pass `-f`):
+
+```sh
+dotnet test tests/Transloadit.Tests/Transloadit.Tests.csproj -f net8.0
+dotnet test tests/Transloadit.Tests/Transloadit.Tests.csproj -f net8.0 --filter "FullyQualifiedName~SignatureTests"
+dotnet test tests/Transloadit.Tests/Transloadit.Tests.csproj -f net8.0 --filter "DisplayName~CreateAsync"
+```
+
+### Test credentials (important)
+
+Most `Tests/Api/*` tests are **integration tests that hit the live Transloadit API** and require credentials. They read `appsettings.Tests.json` from the test output directory at runtime. This file is gitignored and absent by default; create it by copying `tests/Transloadit.Tests/appsettings.json` and filling in `AuthKey`, `AuthSecret`, and `NotifyUrl`. Without it, `TestBase` throws at construction and API tests fail. Pure-unit tests (e.g. `SignatureTests`, `SerializationDefaultsTests`, `ProjectTests`, robot serialization in `NewRobotsTests`) do not need credentials. Test parallelization is disabled globally (see the assembly attribute in `Tests/TestBase.cs`) because integration tests share account-level rate limits.
+
+## Build settings that affect all code
+
+- `TreatWarningsAsErrors` is **true** — any warning fails the build. This includes missing XML doc comments, since `GenerateDocumentationFile` is on. Every public type and member needs a `///` doc comment.
+- `Nullable` is **disabled** — do not add nullable reference annotations (`string?`); use `?` only for nullable value types.
+- `LangVersion` is **12**, but the library targets frameworks as old as `net452`/`netstandard2.0`. Avoid APIs unavailable on old targets; framework gaps are bridged in `src/Transloadit/Polyfills/`. Framework-conditional package references live in `Directory.Build.props`.
+- The assembly is strong-name signed (`SignAssembly`).
+
+## Architecture
+
+The public surface is `TransloaditClient` (`src/Transloadit/TransloaditClient.cs`), constructed with an auth key (and optionally a secret). Key-only clients can do unsigned operations (assembly create/status/cancel); key+secret is required for anything needing signature authentication.
+
+**Services.** The client exposes API areas as lazily-instantiated service properties: `Assemblies`, `Templates`, `Credentials`, `Queues`, `Billing`, `AssemblyNotifications`, `Tokens`. Each service (`src/Transloadit/Services/`) holds a reference back to the client and turns typed request models into calls to the client's central `SendRequest<T>` method. To add an endpoint, add a method to the relevant service; to add an API area, add a service class and a lazy property on `TransloaditClient`.
+
+**Request pipeline.** `TransloaditClient.SendRequest<T>` / `BuildRequest` is the single choke point for every request. It:
+- serializes the `BaseParams`-derived parameter object to a JSON `params` field,
+- injects `auth.key`, and (when signature auth is enabled and a secret is present) an `expires` timestamp plus a signature computed by `SignatureUtilities`,
+- places `params`/`signature` in the query string for GET and in multipart form data for POST/PUT/DELETE,
+- deserializes the response into a `ResponseBase`-derived type and attaches the raw `TransloaditResponse` (status code, headers, body).
+
+Signature auth is on by default per request; endpoints that must not sign set `EnableSignatureAuth = false` on their `BaseParams` (see `AssembliesService.GetAsync`). OAuth token requests go through the separate `SendTokenRequest` path using HTTP Basic auth.
+
+**Models** (`src/Transloadit/Models/`) are split into requests and responses:
+- Request params derive from `BaseParams` / `PaginationParams` (`Models/BaseRequests.cs`).
+- Responses derive from `ResponseBase` (`Models/BaseResponses.cs`), which implements `IResponseBase` explicitly to hide the raw `ok`/`error` fields behind a `Base` accessor and exposes `IsSuccessResponse()`. Check `IsSuccessResponse()` rather than inspecting status codes directly.
+
+**Robots.** Assembly/template steps are modeled as strongly-typed classes under `Models/Robots/<category>/`, all deriving from `RobotBase` (with `ImportRobotBase`, `StoreRobotBase`, `PaginatedImportRobotBase` intermediates). Each concrete robot sets its `Robot` string (e.g. `/ftp/import`) in its constructor and links to the corresponding Transloadit docs page in its XML summary. Steps are supplied as `Dictionary<string, RobotBase>`. When adding a robot, mirror this pattern: pick the right base class, set `Robot` in the constructor, map every property with `[JsonProperty("snake_case_name")]`, and document each with `///`.
+
+**Serialization.** `TransloaditSerializerSettings.CreateDefault()` (`src/Transloadit/Serialization/`) is the default Newtonsoft config: `NullValueHandling.Ignore`, `SnakeCaseNamingStrategy`, and the custom `AnyOfConverter`. Callers can customize by passing settings via `TransloaditClientOptions`. The `AnyOf<...>` union types (`Models/AnyOf.cs`) model API fields that accept multiple shapes (e.g. a string *or* a list); `AnyOfConverter` handles their JSON. Other custom converters: `BooleanToIntConverter`, and the `DateTimeConverters` used for `expires`/pagination dates.
+
+**Constants** (`src/Transloadit/Constants/`) are static classes of string literals for API enum-like values (presets, stacks, formats, response codes). Prefer referencing these over raw strings.
+
+## Conventions
+
+- Comments start with a lowercase letter and need no trailing period.
+- Reference types, methods, and properties in prose with backticks.
+- Make minimal, well-scoped changes; avoid new dependencies.
+- Async methods use `.ConfigureAwait(false)` throughout and are suffixed `Async`.
+- When editing `readme.md`, keep examples runnable (include `using` directives, note async context) and use `csharp` fences; forward-slash paths like `images/snowflake.jpg` are fine in docs.
+
+## Release
+
+`Version` is set in `src/Transloadit/Transloadit.csproj`. The `NuGet Deploy` workflow (`.github/workflows/deploy.yml`, manual `workflow_dispatch`) runs the test matrix, packs, tags the commit `v<Version>` if that tag doesn't exist, and pushes to nuget.org. Bump `<Version>` before deploying a release.

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <!-- coverlet's cross-platform collector, shipped via the coverlet.collector package -->
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <!-- measure the library only, not the test assembly or third-party code -->
+          <Exclude>[Transloadit.Tests]*,[xunit.*]*</Exclude>
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>false</UseSourceLink>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/tests/Transloadit.Tests/Infrastructure/FakeHttpMessageHandler.cs
+++ b/tests/Transloadit.Tests/Infrastructure/FakeHttpMessageHandler.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Transloadit.Tests.Infrastructure
+{
+    // captures outgoing requests and returns canned responses so the client
+    // request/response pipeline can be exercised without touching the network
+    internal sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, int, HttpResponseMessage> _responder;
+        private int _callCount;
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, int, HttpResponseMessage> responder)
+        {
+            _responder = responder;
+        }
+
+        public int CallCount => _callCount;
+        public HttpRequestMessage LastRequest { get; private set; }
+        public Uri LastRequestUri { get; private set; }
+        public HttpMethod LastMethod { get; private set; }
+        public string LastRequestContent { get; private set; }
+        public List<string> RequestContents { get; } = new List<string>();
+        public List<Uri> RequestUris { get; } = new List<Uri>();
+
+        // always responds with the same json body
+        public static FakeHttpMessageHandler Json(string json, HttpStatusCode status = HttpStatusCode.OK)
+            => new FakeHttpMessageHandler((_, __) => Respond(json, status));
+
+        // responds with each body in order; repeats the last one once exhausted
+        public static FakeHttpMessageHandler Sequence(params string[] jsonBodies)
+            => new FakeHttpMessageHandler((_, i) => Respond(jsonBodies[Math.Min(i, jsonBodies.Length - 1)]));
+
+        private static HttpResponseMessage Respond(string json, HttpStatusCode status = HttpStatusCode.OK)
+            => new HttpResponseMessage(status)
+            {
+                Content = new StringContent(json ?? string.Empty, Encoding.UTF8, "application/json"),
+            };
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var index = _callCount++;
+            LastRequest = request;
+            LastRequestUri = request.RequestUri;
+            LastMethod = request.Method;
+            RequestUris.Add(request.RequestUri);
+
+            string content = null;
+            if (request.Content != null)
+            {
+                content = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+            }
+
+            LastRequestContent = content;
+            RequestContents.Add(content);
+
+            return _responder(request, index);
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Infrastructure/TestClientFactory.cs
+++ b/tests/Transloadit.Tests/Infrastructure/TestClientFactory.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Net.Http;
+
+namespace Transloadit.Tests.Infrastructure
+{
+    // builds a TransloaditClient wired to a fake handler, so no network is touched
+    internal static class TestClientFactory
+    {
+        public const string Key = "test-key";
+        public const string Secret = "test-secret";
+
+        public static readonly Uri ApiBase = new Uri("https://api.test/");
+
+        public static TransloaditClient Create(FakeHttpMessageHandler handler, bool withSecret = true)
+        {
+            var options = new TransloaditClientOptions
+            {
+                ApiBase = ApiBase,
+                HttpClient = new HttpClient(handler),
+            };
+
+            return withSecret
+                ? new TransloaditClient(Key, Secret, options)
+                : new TransloaditClient(Key, options);
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Snapshots/models.serialization.snapshot.json
+++ b/tests/Transloadit.Tests/Snapshots/models.serialization.snapshot.json
@@ -1,0 +1,7231 @@
+[
+  {
+    "type": "Transloadit.Models.Assemblies.AssemblyCompactResponse",
+    "properties": [
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "created",
+        "type": "DateTimeOffset"
+      },
+      {
+        "name": "created_ts",
+        "type": "Int64"
+      },
+      {
+        "name": "error",
+        "type": "String"
+      },
+      {
+        "name": "execution_duration",
+        "type": "Double"
+      },
+      {
+        "name": "execution_start",
+        "type": "DateTimeOffset"
+      },
+      {
+        "name": "files",
+        "type": "String"
+      },
+      {
+        "name": "http_code",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "id",
+        "type": "String"
+      },
+      {
+        "name": "instance",
+        "type": "String"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "notify_url",
+        "type": "String"
+      },
+      {
+        "name": "num_input_files",
+        "type": "Int32"
+      },
+      {
+        "name": "ok",
+        "type": "String"
+      },
+      {
+        "name": "parent_id",
+        "type": "String"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      },
+      {
+        "name": "redirect_url",
+        "type": "String"
+      },
+      {
+        "name": "region",
+        "type": "String"
+      },
+      {
+        "name": "template_id",
+        "type": "String"
+      },
+      {
+        "name": "template_name",
+        "type": "String"
+      },
+      {
+        "name": "warning_count",
+        "type": "Int32"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Assemblies.AssemblyListRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "fromdate",
+        "type": "Nullable<DateTime>",
+        "converter": "PaginationDateTimeConverter"
+      },
+      {
+        "name": "keywords",
+        "type": "List<String>"
+      },
+      {
+        "name": "page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "pagesize",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "todate",
+        "type": "Nullable<DateTime>",
+        "converter": "PaginationDateTimeConverter"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Assemblies.AssemblyRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "fields",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "notify_url",
+        "type": "String"
+      },
+      {
+        "name": "quiet",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "steps",
+        "type": "Dictionary<String, RobotBase>"
+      },
+      {
+        "name": "template_id",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Assemblies.AssemblyResponse",
+    "properties": [
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "account_name",
+        "type": "String"
+      },
+      {
+        "name": "account_slug",
+        "type": "String"
+      },
+      {
+        "name": "api_auth_key_id",
+        "type": "String"
+      },
+      {
+        "name": "assembly_id",
+        "type": "String"
+      },
+      {
+        "name": "assembly_ssl_url",
+        "type": "String"
+      },
+      {
+        "name": "assembly_url",
+        "type": "String"
+      },
+      {
+        "name": "build_id",
+        "type": "String"
+      },
+      {
+        "name": "bytes_expected",
+        "type": "Int64"
+      },
+      {
+        "name": "bytes_received",
+        "type": "Int64"
+      },
+      {
+        "name": "bytes_usage",
+        "type": "Int64"
+      },
+      {
+        "name": "client_agent",
+        "type": "String"
+      },
+      {
+        "name": "client_ip",
+        "type": "String"
+      },
+      {
+        "name": "client_referer",
+        "type": "String"
+      },
+      {
+        "name": "companion_url",
+        "type": "String"
+      },
+      {
+        "name": "error",
+        "type": "String"
+      },
+      {
+        "name": "executing_jobs",
+        "type": "List<String>"
+      },
+      {
+        "name": "execution_duration",
+        "type": "Double"
+      },
+      {
+        "name": "execution_start",
+        "type": "DateTimeOffset"
+      },
+      {
+        "name": "expected_tus_uploads",
+        "type": "Int32"
+      },
+      {
+        "name": "fields",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "finished_tus_uploads",
+        "type": "Int32"
+      },
+      {
+        "name": "has_dupe_jobs",
+        "type": "Boolean"
+      },
+      {
+        "name": "http_code",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "instance",
+        "type": "String"
+      },
+      {
+        "name": "is_infinite",
+        "type": "Boolean"
+      },
+      {
+        "name": "jobs_queue_duration",
+        "type": "Double"
+      },
+      {
+        "name": "last_job_completed",
+        "type": "Nullable<DateTimeOffset>"
+      },
+      {
+        "name": "merged_params",
+        "type": "String"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "notify_duration",
+        "type": "Nullable<Double>"
+      },
+      {
+        "name": "notify_response_code",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "notify_response_data",
+        "type": "String"
+      },
+      {
+        "name": "notify_start",
+        "type": "Nullable<DateTimeOffset>"
+      },
+      {
+        "name": "notify_url",
+        "type": "String"
+      },
+      {
+        "name": "num_input_files",
+        "type": "Int32"
+      },
+      {
+        "name": "ok",
+        "type": "String"
+      },
+      {
+        "name": "params",
+        "type": "String"
+      },
+      {
+        "name": "parent_assembly_status",
+        "type": "Object"
+      },
+      {
+        "name": "parent_id",
+        "type": "String"
+      },
+      {
+        "name": "queue_duration",
+        "type": "Double"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      },
+      {
+        "name": "region",
+        "type": "String"
+      },
+      {
+        "name": "results",
+        "type": "Dictionary<String, List<FileResult>>"
+      },
+      {
+        "name": "running_jobs",
+        "type": "List<Object>"
+      },
+      {
+        "name": "start_date",
+        "type": "DateTimeOffset"
+      },
+      {
+        "name": "started_jobs",
+        "type": "List<String>"
+      },
+      {
+        "name": "started_tus_uploads",
+        "type": "Int32"
+      },
+      {
+        "name": "template",
+        "type": "String"
+      },
+      {
+        "name": "template_id",
+        "type": "String"
+      },
+      {
+        "name": "template_name",
+        "type": "String"
+      },
+      {
+        "name": "transloadit_client",
+        "type": "String"
+      },
+      {
+        "name": "tus_uploads",
+        "type": "List<TusUpload>"
+      },
+      {
+        "name": "tus_url",
+        "type": "String"
+      },
+      {
+        "name": "update_stream_url",
+        "type": "String"
+      },
+      {
+        "name": "upload_duration",
+        "type": "Double"
+      },
+      {
+        "name": "upload_meta_data_extracted",
+        "type": "Boolean"
+      },
+      {
+        "name": "uploads",
+        "type": "List<Upload>"
+      },
+      {
+        "name": "uppyserver_url",
+        "type": "String"
+      },
+      {
+        "name": "usage_tags",
+        "type": "String"
+      },
+      {
+        "name": "warnings",
+        "type": "List<AssemblyWarning>"
+      },
+      {
+        "name": "websocket_url",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Assemblies.AssemblyWarning",
+    "properties": [
+      {
+        "name": "level",
+        "type": "String"
+      },
+      {
+        "name": "msg",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Assemblies.FileResult",
+    "properties": [
+      {
+        "name": "as",
+        "type": "String"
+      },
+      {
+        "name": "basename",
+        "type": "String"
+      },
+      {
+        "name": "cost",
+        "type": "Int32"
+      },
+      {
+        "name": "exec_time",
+        "type": "Double"
+      },
+      {
+        "name": "ext",
+        "type": "String"
+      },
+      {
+        "name": "field",
+        "type": "String"
+      },
+      {
+        "name": "from_batch_import",
+        "type": "Boolean"
+      },
+      {
+        "name": "id",
+        "type": "String"
+      },
+      {
+        "name": "is_temp_url",
+        "type": "Boolean"
+      },
+      {
+        "name": "is_tus_file",
+        "type": "Boolean"
+      },
+      {
+        "name": "md5hash",
+        "type": "String"
+      },
+      {
+        "name": "meta",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "mime",
+        "type": "String"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "original_basename",
+        "type": "String"
+      },
+      {
+        "name": "original_id",
+        "type": "String"
+      },
+      {
+        "name": "original_md5hash",
+        "type": "String"
+      },
+      {
+        "name": "original_name",
+        "type": "String"
+      },
+      {
+        "name": "original_path",
+        "type": "String"
+      },
+      {
+        "name": "queue",
+        "type": "String"
+      },
+      {
+        "name": "queue_time",
+        "type": "Double"
+      },
+      {
+        "name": "size",
+        "type": "Int32"
+      },
+      {
+        "name": "ssl_url",
+        "type": "String"
+      },
+      {
+        "name": "tus_upload_url",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      },
+      {
+        "name": "url",
+        "type": "String"
+      },
+      {
+        "name": "user_meta",
+        "type": "Dictionary<String, Object>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Assemblies.ReplayAssemblyRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "fields",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "notify_url",
+        "type": "String"
+      },
+      {
+        "name": "reparse_template",
+        "type": "Nullable<Boolean>",
+        "converter": "BooleanToIntConverter"
+      },
+      {
+        "name": "steps",
+        "type": "Dictionary<String, RobotBase>"
+      },
+      {
+        "name": "template_id",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Assemblies.ReplayAssemblyResponse",
+    "properties": [
+      {
+        "name": "assembly_id",
+        "type": "String"
+      },
+      {
+        "name": "assembly_ssl_url",
+        "type": "String"
+      },
+      {
+        "name": "assembly_url",
+        "type": "String"
+      },
+      {
+        "name": "error",
+        "type": "String"
+      },
+      {
+        "name": "http_code",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "notify_url",
+        "type": "String"
+      },
+      {
+        "name": "ok",
+        "type": "String"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      },
+      {
+        "name": "success",
+        "type": "Boolean"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Assemblies.TusUpload",
+    "properties": [
+      {
+        "name": "fieldname",
+        "type": "String"
+      },
+      {
+        "name": "filename",
+        "type": "String"
+      },
+      {
+        "name": "finished",
+        "type": "Boolean"
+      },
+      {
+        "name": "local_path",
+        "type": "String"
+      },
+      {
+        "name": "offset",
+        "type": "Int32"
+      },
+      {
+        "name": "size",
+        "type": "Int32"
+      },
+      {
+        "name": "upload_url",
+        "type": "String"
+      },
+      {
+        "name": "user_meta",
+        "type": "Dictionary<String, Object>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Assemblies.Upload",
+    "properties": [
+      {
+        "name": "as",
+        "type": "String"
+      },
+      {
+        "name": "basename",
+        "type": "String"
+      },
+      {
+        "name": "exec_time",
+        "type": "Double"
+      },
+      {
+        "name": "ext",
+        "type": "String"
+      },
+      {
+        "name": "field",
+        "type": "String"
+      },
+      {
+        "name": "from_batch_import",
+        "type": "Boolean"
+      },
+      {
+        "name": "id",
+        "type": "String"
+      },
+      {
+        "name": "is_tus_file",
+        "type": "Boolean"
+      },
+      {
+        "name": "md5hash",
+        "type": "String"
+      },
+      {
+        "name": "meta",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "mime",
+        "type": "String"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "original_basename",
+        "type": "String"
+      },
+      {
+        "name": "original_id",
+        "type": "String"
+      },
+      {
+        "name": "original_md5hash",
+        "type": "String"
+      },
+      {
+        "name": "original_name",
+        "type": "String"
+      },
+      {
+        "name": "original_path",
+        "type": "String"
+      },
+      {
+        "name": "queue",
+        "type": "String"
+      },
+      {
+        "name": "queue_time",
+        "type": "Double"
+      },
+      {
+        "name": "size",
+        "type": "Int32"
+      },
+      {
+        "name": "ssl_url",
+        "type": "String"
+      },
+      {
+        "name": "tus_upload_url",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      },
+      {
+        "name": "url",
+        "type": "String"
+      },
+      {
+        "name": "user_meta",
+        "type": "Dictionary<String, Object>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.AssemblyNotifications.ReplayNotificationRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "notify_url",
+        "type": "String"
+      },
+      {
+        "name": "wait",
+        "type": "Nullable<Boolean>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.AssemblyNotifications.ReplayNotificationResponse",
+    "properties": [
+      {
+        "name": "error",
+        "type": "String"
+      },
+      {
+        "name": "http_code",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "ok",
+        "type": "String"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.AuthParams",
+    "properties": [
+      {
+        "name": "expires",
+        "type": "Nullable<DateTime>",
+        "converter": "AuthExpiresDateTimeConverter"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "max_size",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "nonce",
+        "type": "String"
+      },
+      {
+        "name": "referer",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.BaseParams",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Billing.BillingPlan",
+    "properties": [
+      {
+        "name": "can_use_assembly_fields_search",
+        "type": "Int32"
+      },
+      {
+        "name": "can_use_image_turbo_mode",
+        "type": "Int32"
+      },
+      {
+        "name": "can_use_video_turbo_mode",
+        "type": "Int32"
+      },
+      {
+        "name": "comments",
+        "type": "String"
+      },
+      {
+        "name": "created",
+        "type": "DateTimeOffset"
+      },
+      {
+        "name": "currency",
+        "type": "String"
+      },
+      {
+        "name": "deleted",
+        "type": "Nullable<DateTimeOffset>"
+      },
+      {
+        "name": "file_size_limit_in_gb",
+        "type": "Nullable<Decimal>"
+      },
+      {
+        "name": "gb_included",
+        "type": "Decimal"
+      },
+      {
+        "name": "gb_limit",
+        "type": "Nullable<Decimal>"
+      },
+      {
+        "name": "has_lifetime_limit",
+        "type": "Int32"
+      },
+      {
+        "name": "id",
+        "type": "String"
+      },
+      {
+        "name": "max_jobs_simulteneous",
+        "type": "Int32"
+      },
+      {
+        "name": "modified",
+        "type": "DateTimeOffset"
+      },
+      {
+        "name": "num_concurrent_batch_job_slots",
+        "type": "Int32"
+      },
+      {
+        "name": "num_concurrent_priority_jobs",
+        "type": "Int32"
+      },
+      {
+        "name": "num_machines",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "num_seats",
+        "type": "Int32"
+      },
+      {
+        "name": "price_per_gb",
+        "type": "Decimal"
+      },
+      {
+        "name": "price_per_machine",
+        "type": "Nullable<Decimal>"
+      },
+      {
+        "name": "price_per_month",
+        "type": "Decimal"
+      },
+      {
+        "name": "published",
+        "type": "Int32"
+      },
+      {
+        "name": "should_watermark_transcoding_results",
+        "type": "Int32"
+      },
+      {
+        "name": "slug",
+        "type": "String"
+      },
+      {
+        "name": "tiers",
+        "type": "Object"
+      },
+      {
+        "name": "title",
+        "type": "String"
+      },
+      {
+        "name": "usd_exchange_rate",
+        "type": "Nullable<Decimal>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Billing.BillingResponse",
+    "properties": [
+      {
+        "name": "additional_gb",
+        "type": "Decimal"
+      },
+      {
+        "name": "additional_gb_fee",
+        "type": "Decimal"
+      },
+      {
+        "name": "address_1",
+        "type": "String"
+      },
+      {
+        "name": "address_2",
+        "type": "String"
+      },
+      {
+        "name": "bill_limit",
+        "type": "Decimal"
+      },
+      {
+        "name": "city",
+        "type": "String"
+      },
+      {
+        "name": "company",
+        "type": "String"
+      },
+      {
+        "name": "country",
+        "type": "String"
+      },
+      {
+        "name": "country_id",
+        "type": "String"
+      },
+      {
+        "name": "coupon_discount",
+        "type": "Decimal"
+      },
+      {
+        "name": "coupon_discount_percent",
+        "type": "Decimal"
+      },
+      {
+        "name": "created",
+        "type": "DateTimeOffset"
+      },
+      {
+        "name": "credit",
+        "type": "Decimal"
+      },
+      {
+        "name": "currency",
+        "type": "String"
+      },
+      {
+        "name": "email",
+        "type": "String"
+      },
+      {
+        "name": "error",
+        "type": "String"
+      },
+      {
+        "name": "final_sub_total",
+        "type": "Decimal"
+      },
+      {
+        "name": "http_code",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "invoice_id",
+        "type": "String"
+      },
+      {
+        "name": "is_prorated",
+        "type": "Boolean"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "month",
+        "type": "String"
+      },
+      {
+        "name": "ok",
+        "type": "String"
+      },
+      {
+        "name": "plan",
+        "type": "BillingPlan"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      },
+      {
+        "name": "reverse_charge_vat",
+        "type": "Boolean"
+      },
+      {
+        "name": "reward_discount",
+        "type": "Decimal"
+      },
+      {
+        "name": "reward_discount_percent",
+        "type": "Decimal"
+      },
+      {
+        "name": "robots",
+        "type": "Dictionary<String, RobotBilling>"
+      },
+      {
+        "name": "signup_discount",
+        "type": "Decimal"
+      },
+      {
+        "name": "signup_discount_percent",
+        "type": "Decimal"
+      },
+      {
+        "name": "state",
+        "type": "String"
+      },
+      {
+        "name": "sub_total",
+        "type": "Decimal"
+      },
+      {
+        "name": "to",
+        "type": "String"
+      },
+      {
+        "name": "to_contact_email_address",
+        "type": "String"
+      },
+      {
+        "name": "total",
+        "type": "Decimal"
+      },
+      {
+        "name": "used_gb",
+        "type": "Decimal"
+      },
+      {
+        "name": "vat",
+        "type": "Decimal"
+      },
+      {
+        "name": "vat_id",
+        "type": "String"
+      },
+      {
+        "name": "vat_rate",
+        "type": "Decimal"
+      },
+      {
+        "name": "zip",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Billing.RobotBilling",
+    "properties": [
+      {
+        "name": "by_region_and_factor",
+        "type": "List<RobotBillingByRegionAndFactor>"
+      },
+      {
+        "name": "discountedGb",
+        "type": "Decimal"
+      },
+      {
+        "name": "factor",
+        "type": "Decimal"
+      },
+      {
+        "name": "freeGb",
+        "type": "Decimal"
+      },
+      {
+        "name": "gb",
+        "type": "Decimal"
+      },
+      {
+        "name": "gbFactorApplied",
+        "type": "Decimal"
+      },
+      {
+        "name": "rawGb",
+        "type": "Decimal"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Billing.RobotBillingByRegionAndFactor",
+    "properties": [
+      {
+        "name": "factor",
+        "type": "Decimal"
+      },
+      {
+        "name": "freeGb",
+        "type": "Decimal"
+      },
+      {
+        "name": "gbFactorApplied",
+        "type": "Decimal"
+      },
+      {
+        "name": "rawGb",
+        "type": "Decimal"
+      },
+      {
+        "name": "region",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.AzureCredentialsContent",
+    "properties": [
+      {
+        "name": "account",
+        "type": "String"
+      },
+      {
+        "name": "container",
+        "type": "String"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.AzureCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "AzureCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.BackblazeCredentialsContent",
+    "properties": [
+      {
+        "name": "app_key",
+        "type": "String"
+      },
+      {
+        "name": "app_key_id",
+        "type": "String"
+      },
+      {
+        "name": "bucket",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.BackblazeCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "BackblazeCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.CloudFlareCredentialsContent",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.CloudflareCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "CloudFlareCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.Credential",
+    "properties": [
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "content",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "created",
+        "type": "DateTimeOffset"
+      },
+      {
+        "name": "deleted",
+        "type": "Nullable<DateTimeOffset>"
+      },
+      {
+        "name": "id",
+        "type": "String"
+      },
+      {
+        "name": "modified",
+        "type": "DateTimeOffset"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "stringified",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.CredentialResponse",
+    "properties": [
+      {
+        "name": "credential",
+        "type": "Credential"
+      },
+      {
+        "name": "error",
+        "type": "String"
+      },
+      {
+        "name": "http_code",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "ok",
+        "type": "String"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.CredentialsListResponse",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "List<Credential>"
+      },
+      {
+        "name": "error",
+        "type": "String"
+      },
+      {
+        "name": "http_code",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "ok",
+        "type": "String"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.CredentialsRequestBase",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.DeleteCredentialsResponse",
+    "properties": [
+      {
+        "name": "error",
+        "type": "String"
+      },
+      {
+        "name": "http_code",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "ok",
+        "type": "String"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.DigitalOceanCredentialsContent",
+    "properties": [
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "region",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      },
+      {
+        "name": "space",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.DigitalOceanCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "DigitalOceanCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.FtpCredentialsContent",
+    "properties": [
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "password",
+        "type": "String"
+      },
+      {
+        "name": "user",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.FtpCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "FtpCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.GenericCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.HttpCredentialsContent",
+    "properties": [
+      {
+        "name": "headers",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.HttpCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "HttpCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.MinioCredentialsContent",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.MinioCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "MinioCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.OAuthCredentialsContent",
+    "properties": [
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.OAuthCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "OAuthCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.RackSpaceCredentialsContent",
+    "properties": [
+      {
+        "name": "account_type",
+        "type": "String"
+      },
+      {
+        "name": "container",
+        "type": "String"
+      },
+      {
+        "name": "data_center",
+        "type": "String"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "user",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.RackspaceCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "RackSpaceCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.S3CredentialsContent",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "bucket_region",
+        "type": "String"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.S3CredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "S3CredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.SftpCredentialsContent",
+    "properties": [
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "port",
+        "type": "Int32"
+      },
+      {
+        "name": "public_key",
+        "type": "String"
+      },
+      {
+        "name": "user",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.SftpCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "SftpCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.SupabaseCredentialsContent",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "bucket_region",
+        "type": "String"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.SupabaseCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "SupabaseCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.SwiftCredentialsContent",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.SwiftCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "SwiftCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.TigrisCredentialsContent",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.TigrisCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "TigrisCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.WasabiCredentialsContent",
+    "properties": [
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "password",
+        "type": "String"
+      },
+      {
+        "name": "user",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.WasabiCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "WasabiCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.PaginationParams",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "fromdate",
+        "type": "Nullable<DateTime>",
+        "converter": "PaginationDateTimeConverter"
+      },
+      {
+        "name": "keywords",
+        "type": "List<String>"
+      },
+      {
+        "name": "page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "pagesize",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "todate",
+        "type": "Nullable<DateTime>",
+        "converter": "PaginationDateTimeConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Queues.PriorityJobSlots",
+    "properties": [
+      {
+        "name": "count",
+        "type": "Int32"
+      },
+      {
+        "name": "slots",
+        "type": "Dictionary<String, Dictionary<String, Dictionary<String, Int32>>>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Queues.QueueResponse",
+    "properties": [
+      {
+        "name": "error",
+        "type": "String"
+      },
+      {
+        "name": "http_code",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "ok",
+        "type": "String"
+      },
+      {
+        "name": "priority_job_slots",
+        "type": "PriorityJobSlots"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.ResponseBase",
+    "properties": [
+      {
+        "name": "error",
+        "type": "String"
+      },
+      {
+        "name": "http_code",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "ok",
+        "type": "String"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AI.AiChatMcpServer",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "String"
+      },
+      {
+        "name": "headers",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "url",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AI.AiChatMessage",
+    "properties": [
+      {
+        "name": "content",
+        "type": "String"
+      },
+      {
+        "name": "role",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AI.AiChatRobot",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "mcp_servers",
+        "type": "List<AiChatMcpServer>"
+      },
+      {
+        "name": "messages",
+        "type": "AnyOf<String, List<AiChatMessage>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "model",
+        "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "reasoning_effort",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "schema",
+        "type": "String"
+      },
+      {
+        "name": "system_message",
+        "type": "String"
+      },
+      {
+        "name": "test_credentials",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AI.DocumentOcrRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "granularity",
+        "type": "String"
+      },
+      {
+        "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AI.ImageDescribeRobot",
+    "properties": [
+      {
+        "name": "explicit_descriptions",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "granularity",
+        "type": "String"
+      },
+      {
+        "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AI.ImageFaceDetectRobot",
+    "properties": [
+      {
+        "name": "crop",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "crop_padding",
+        "type": "String"
+      },
+      {
+        "name": "faces",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "min_confidence",
+        "type": "Int32"
+      },
+      {
+        "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AI.ImageGenerateRobot",
+    "properties": [
+      {
+        "name": "aspect_ratio",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "height",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "model",
+        "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "prompt",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "seed",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "style",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "width",
+        "type": "Nullable<Int32>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AI.ImageOcrRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "granularity",
+        "type": "String"
+      },
+      {
+        "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AI.SpeechTranscribeRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "granularity",
+        "type": "String"
+      },
+      {
+        "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "source_language",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AI.TextSpeakRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "prompt",
+        "type": "String"
+      },
+      {
+        "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "ssml",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "target_language",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "voice",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AI.TextTranslateRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "source_language",
+        "type": "String"
+      },
+      {
+        "name": "target_language",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AI.VideoGenerateRobot",
+    "properties": [
+      {
+        "name": "aspect_ratio",
+        "type": "String"
+      },
+      {
+        "name": "camera_motion",
+        "type": "String"
+      },
+      {
+        "name": "duration",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "fps",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "height",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "model",
+        "type": "String"
+      },
+      {
+        "name": "motion_amount",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "negative_prompt",
+        "type": "String"
+      },
+      {
+        "name": "num_outputs",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "prompt",
+        "type": "String"
+      },
+      {
+        "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "reference_strength",
+        "type": "AnyOf<Double, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "seed",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "style",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "width",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AdvancedStep",
+    "properties": [
+      {
+        "name": "as",
+        "type": "String"
+      },
+      {
+        "name": "fields",
+        "type": "String"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AdvancedUse",
+    "properties": [
+      {
+        "name": "bundle_steps",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "fields",
+        "type": "List<String>"
+      },
+      {
+        "name": "group_by_original",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "steps",
+        "type": "AnyOf<List<String>, List<AdvancedStep>>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AudioEncoding.AudioArtworkRobot",
+    "properties": [
+      {
+        "name": "change_format_if_necessary",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "method",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AudioEncoding.AudioConcatenateRobot",
+    "properties": [
+      {
+        "name": "audio_fade_seconds",
+        "type": "Nullable<Double>"
+      },
+      {
+        "name": "bitrate",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "ffmpeg",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "sample_rate",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AudioEncoding.AudioEncodeRobot",
+    "properties": [
+      {
+        "name": "bitrate",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "ffmpeg",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "sample_rate",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AudioEncoding.AudioLoopRobot",
+    "properties": [
+      {
+        "name": "bitrate",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "duration",
+        "type": "Nullable<Double>"
+      },
+      {
+        "name": "ffmpeg",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "sample_rate",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AudioEncoding.AudioMergeRobot",
+    "properties": [
+      {
+        "name": "bitrate",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "duration",
+        "type": "String"
+      },
+      {
+        "name": "ffmpeg",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "loop",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "sample_rate",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "volume",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AudioEncoding.AudioSplitRobot",
+    "properties": [
+      {
+        "name": "bitrate",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "ffmpeg",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "sample_rate",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "segments",
+        "type": "List<AudioSplitSegment>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AudioEncoding.AudioSplitSegment",
+    "properties": [
+      {
+        "name": "from",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "to",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.AudioEncoding.AudioWaveformImageRobot",
+    "properties": [
+      {
+        "name": "antialiasing",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "background_color",
+        "type": "String"
+      },
+      {
+        "name": "center_color",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "height",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "outer_color",
+        "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "style",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "width",
+        "type": "Nullable<Int32>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.Code.ScriptRunRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "script",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.Documents.DocumentAutoRotateRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.Documents.DocumentConvertRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "markdown_format",
+        "type": "String"
+      },
+      {
+        "name": "markdown_theme",
+        "type": "String"
+      },
+      {
+        "name": "pdf_display_header_footer",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "pdf_footer_template",
+        "type": "String"
+      },
+      {
+        "name": "pdf_format",
+        "type": "String"
+      },
+      {
+        "name": "pdf_header_template",
+        "type": "String"
+      },
+      {
+        "name": "pdf_margin",
+        "type": "String"
+      },
+      {
+        "name": "pdf_print_background",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.Documents.DocumentMergeRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "input_passwords",
+        "type": "List<String>"
+      },
+      {
+        "name": "output_password",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.Documents.DocumentOptimizeRobot",
+    "properties": [
+      {
+        "name": "compatibility",
+        "type": "String"
+      },
+      {
+        "name": "compress_fonts",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "image_dpi",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "linearize",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "remove_metadata",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "subset_fonts",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.Documents.DocumentSplitRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "pages",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.Documents.DocumentThumbnailsRobot",
+    "properties": [
+      {
+        "name": "alpha",
+        "type": "String"
+      },
+      {
+        "name": "antialiasing",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "background",
+        "type": "String"
+      },
+      {
+        "name": "colorspace",
+        "type": "String"
+      },
+      {
+        "name": "delay",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "density",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "height",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "imagemagick_stack",
+        "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "pdf_use_cropbox",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "resize_strategy",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "trim_whitespace",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "width",
+        "type": "Nullable<Int32>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.Documents.FileReadRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.Documents.HtmlConvertRobot",
+    "properties": [
+      {
+        "name": "delay",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "fullpage",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "headers",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "height",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "omit_background",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "url",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "width",
+        "type": "Nullable<Int32>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileCompressing.FileCompressRobot",
+    "properties": [
+      {
+        "name": "compression_level",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "file_layout",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "gzip",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "password",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileCompressing.FileDecompressRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.AzureStoreRobot",
+    "properties": [
+      {
+        "name": "account",
+        "type": "String"
+      },
+      {
+        "name": "cache_control",
+        "type": "String"
+      },
+      {
+        "name": "container",
+        "type": "String"
+      },
+      {
+        "name": "content_encoding",
+        "type": "String"
+      },
+      {
+        "name": "content_language",
+        "type": "String"
+      },
+      {
+        "name": "content_type",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "metadata",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "sas_expires_in",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "sas_permissions",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.BackBlazeStoreRobot",
+    "properties": [
+      {
+        "name": "app_key",
+        "type": "String"
+      },
+      {
+        "name": "app_key_id",
+        "type": "String"
+      },
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "headers",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.BoxStoreRobot",
+    "properties": [
+      {
+        "name": "create_sharing_link",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.CloudFlareStoreRobot",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "headers",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      },
+      {
+        "name": "sign_urls_for",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.DigitalOceanStoreRobot",
+    "properties": [
+      {
+        "name": "acl",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "headers",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "region",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      },
+      {
+        "name": "sign_urls_for",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "space",
+        "type": "String"
+      },
+      {
+        "name": "url_prefix",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.DropboxStoreRobot",
+    "properties": [
+      {
+        "name": "create_sharing_link",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.FtpStoreRobot",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "password",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "port",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secure",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ssl_url_template",
+        "type": "String"
+      },
+      {
+        "name": "url_template",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "user",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.GoogleStorageStoreRobot",
+    "properties": [
+      {
+        "name": "acl",
+        "type": "String"
+      },
+      {
+        "name": "cache_control",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "ssl_url_template",
+        "type": "String"
+      },
+      {
+        "name": "url_template",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.MinioStoreRobot",
+    "properties": [
+      {
+        "name": "acl",
+        "type": "String"
+      },
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "headers",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      },
+      {
+        "name": "sign_urls_for",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.RackSpaceCloudFilesStoreRobot",
+    "properties": [
+      {
+        "name": "account_type",
+        "type": "String"
+      },
+      {
+        "name": "container",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "data_center",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "user",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.S3StoreRobot",
+    "properties": [
+      {
+        "name": "acl",
+        "type": "String"
+      },
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "bucket_region",
+        "type": "String"
+      },
+      {
+        "name": "check_integrity",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "headers",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "no_vhost",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      },
+      {
+        "name": "sign_urls_for",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "tags",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "url_prefix",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.SftpStoreRobot",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "file_chmod",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "port",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "public_key",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "ssl_url_template",
+        "type": "String"
+      },
+      {
+        "name": "url_template",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "user",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.SupabaseStoreRobot",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "bucket_region",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "headers",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      },
+      {
+        "name": "sign_urls_for",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.SwiftStoreRobot",
+    "properties": [
+      {
+        "name": "acl",
+        "type": "String"
+      },
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "headers",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      },
+      {
+        "name": "sign_urls_for",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.TigrisStoreRobot",
+    "properties": [
+      {
+        "name": "acl",
+        "type": "String"
+      },
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "headers",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      },
+      {
+        "name": "sign_urls_for",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.TusStoreRobot",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "endpoint",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "headers",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "metadata",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "ssl_url_template",
+        "type": "String"
+      },
+      {
+        "name": "url_template",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.VimeoStoreRobot",
+    "properties": [
+      {
+        "name": "acl",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "description",
+        "type": "String"
+      },
+      {
+        "name": "downloadable",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "folder_id",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "password",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "showcases",
+        "type": "List<String>"
+      },
+      {
+        "name": "title",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.WasabiStoreRobot",
+    "properties": [
+      {
+        "name": "acl",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "headers",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "password",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "sign_urls_for",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "user",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileExporting.YoutubeStoreRobot",
+    "properties": [
+      {
+        "name": "category",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "description",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "keywords",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "title",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "visibility",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileFiltering.FileFilterRobot",
+    "properties": [
+      {
+        "name": "accepts",
+        "type": "AnyOf<String, List<List<String>>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "condition_type",
+        "type": "String"
+      },
+      {
+        "name": "declines",
+        "type": "AnyOf<String, List<List<String>>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "error_msg",
+        "type": "String"
+      },
+      {
+        "name": "error_on_decline",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileFiltering.FileVerifyRobot",
+    "properties": [
+      {
+        "name": "error_msg",
+        "type": "String"
+      },
+      {
+        "name": "error_on_decline",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "verify_to_be",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileFiltering.FileVirusScanRobot",
+    "properties": [
+      {
+        "name": "error_msg",
+        "type": "String"
+      },
+      {
+        "name": "error_on_decline",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.AzureImportRobot",
+    "properties": [
+      {
+        "name": "account",
+        "type": "String"
+      },
+      {
+        "name": "container",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "files_per_page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "next_page_token",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.BackBlazeImportRobot",
+    "properties": [
+      {
+        "name": "app_key",
+        "type": "String"
+      },
+      {
+        "name": "app_key_id",
+        "type": "String"
+      },
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "files_per_page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "recursive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "start_file_name",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.BoxImportRobot",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.CloudFlareImportRobot",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "files_per_page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "page_number",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "recursive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.DigitalOceanImportRobot",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "files_per_page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "page_number",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "recursive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "region",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      },
+      {
+        "name": "space",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.DropboxImportRobot",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.FtpImportRobot",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "passive_mode",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "password",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "String"
+      },
+      {
+        "name": "port",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "user",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.GoogleStorageImportRobot",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "files_per_page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "next_page_token",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "recursive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.HttpImportRobot",
+    "properties": [
+      {
+        "name": "fail_fast",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "headers",
+        "type": "List<String>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "url",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "url_delimiter",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.MinioImportRobot",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "files_per_page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "page_number",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "recursive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.RackSpaceCloudFilesImportRobot",
+    "properties": [
+      {
+        "name": "account_type",
+        "type": "String"
+      },
+      {
+        "name": "container",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "data_center",
+        "type": "String"
+      },
+      {
+        "name": "files_per_page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "page_number",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "recursive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "user",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.S3ImportRobot",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "bucket_region",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "files_per_page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "page_number",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "recursive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.SftpImportRobot",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "String"
+      },
+      {
+        "name": "port",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.SupabaseImportRobot",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "bucket_region",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "files_per_page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "page_number",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "recursive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.SwiftImportRobot",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "files_per_page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "page_number",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "recursive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.TigrisImportRobot",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "files_per_page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "key",
+        "type": "String"
+      },
+      {
+        "name": "page_number",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "recursive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "return_file_stubs",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "secret",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.VimeoImportRobot",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "files_per_page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "page_number",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "rendition",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.FileImporting.WasabiImportRobot",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "files_per_page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "host",
+        "type": "String"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "page_number",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "password",
+        "type": "String"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "recursive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "user",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.ImageManipulation.BlurRegion",
+    "properties": [
+      {
+        "name": "height",
+        "type": "Int32"
+      },
+      {
+        "name": "width",
+        "type": "Int32"
+      },
+      {
+        "name": "x",
+        "type": "Int32"
+      },
+      {
+        "name": "y",
+        "type": "Int32"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.ImageManipulation.Crop",
+    "properties": [
+      {
+        "name": "x1",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "x2",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "y1",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "y2",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.ImageManipulation.ImageBackgroundRemove",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.ImageManipulation.ImageMergeRobot",
+    "properties": [
+      {
+        "name": "adaptive_filtering",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "background",
+        "type": "String"
+      },
+      {
+        "name": "border",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "direction",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "quality",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.ImageManipulation.ImageOptimizeRobot",
+    "properties": [
+      {
+        "name": "fix_breaking_images",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "preserve_meta_data",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "priority",
+        "type": "String"
+      },
+      {
+        "name": "progressive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.ImageManipulation.ImageResizeRobot",
+    "properties": [
+      {
+        "name": "adaptive_filtering",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "alpha",
+        "type": "String"
+      },
+      {
+        "name": "background",
+        "type": "String"
+      },
+      {
+        "name": "blur",
+        "type": "String"
+      },
+      {
+        "name": "blur_regions",
+        "type": "List<BlurRegion>"
+      },
+      {
+        "name": "brightness",
+        "type": "Nullable<Double>"
+      },
+      {
+        "name": "clip",
+        "type": "AnyOf<Boolean, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "colorspace",
+        "type": "String"
+      },
+      {
+        "name": "compress",
+        "type": "String"
+      },
+      {
+        "name": "correct_gamma",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "crop",
+        "type": "AnyOf<String, Crop>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "density",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "flatten",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "frame",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "gravity",
+        "type": "String"
+      },
+      {
+        "name": "height",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "hue",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "imagemagick_stack",
+        "type": "String"
+      },
+      {
+        "name": "negate",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "preclip_alpha",
+        "type": "String"
+      },
+      {
+        "name": "progressive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "quality",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "resize_strategy",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "rotation",
+        "type": "AnyOf<Boolean, Int32>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "saturation",
+        "type": "Nullable<Double>"
+      },
+      {
+        "name": "sepia",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "strip",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "text",
+        "type": "List<TextData>"
+      },
+      {
+        "name": "transparent",
+        "type": "String"
+      },
+      {
+        "name": "trim_whitespace",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "watermark_position",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "watermark_resize_strategy",
+        "type": "String"
+      },
+      {
+        "name": "watermark_size",
+        "type": "String"
+      },
+      {
+        "name": "watermark_url",
+        "type": "String"
+      },
+      {
+        "name": "watermark_x_offset",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "watermark_y_offset",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "width",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "zoom",
+        "type": "Nullable<Boolean>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.ImageManipulation.ImageUpscaleRobot",
+    "properties": [
+      {
+        "name": "face_enhance",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "model",
+        "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "scale",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.ImageManipulation.TextData",
+    "properties": [
+      {
+        "name": "align",
+        "type": "String"
+      },
+      {
+        "name": "background_color",
+        "type": "String"
+      },
+      {
+        "name": "color",
+        "type": "String"
+      },
+      {
+        "name": "font",
+        "type": "String"
+      },
+      {
+        "name": "rotate",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "size",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "stroke_color",
+        "type": "String"
+      },
+      {
+        "name": "stroke_width",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "text",
+        "type": "String"
+      },
+      {
+        "name": "valign",
+        "type": "String"
+      },
+      {
+        "name": "x_offset",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "y_offset",
+        "type": "Nullable<Int32>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.ImportRobotBase",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.MediaCataloging.FileHashRobot",
+    "properties": [
+      {
+        "name": "algorithm",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.MediaCataloging.FilePreviewRobot",
+    "properties": [
+      {
+        "name": "background",
+        "type": "String"
+      },
+      {
+        "name": "clip_duration",
+        "type": "Nullable<Double>"
+      },
+      {
+        "name": "clip_format",
+        "type": "String"
+      },
+      {
+        "name": "clip_framerate",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "clip_loop",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "clip_offset",
+        "type": "Nullable<Double>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "height",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "icon_style",
+        "type": "String"
+      },
+      {
+        "name": "icon_text_color",
+        "type": "String"
+      },
+      {
+        "name": "icon_text_content",
+        "type": "String"
+      },
+      {
+        "name": "icon_text_font",
+        "type": "String"
+      },
+      {
+        "name": "optimize",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "optimize_priority",
+        "type": "String"
+      },
+      {
+        "name": "optimize_progressive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "resize_strategy",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "strategy",
+        "type": "PreviewStrategy"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "waveform_center_color",
+        "type": "String"
+      },
+      {
+        "name": "waveform_height",
+        "type": "String"
+      },
+      {
+        "name": "waveform_outer_color",
+        "type": "String"
+      },
+      {
+        "name": "waveform_width",
+        "type": "String"
+      },
+      {
+        "name": "width",
+        "type": "Nullable<Int32>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.MediaCataloging.MetadataWriteRobot",
+    "properties": [
+      {
+        "name": "data_to_write",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.MediaCataloging.PreviewStrategy",
+    "properties": [
+      {
+        "name": "archive",
+        "type": "List<String>"
+      },
+      {
+        "name": "audio",
+        "type": "List<String>"
+      },
+      {
+        "name": "document",
+        "type": "List<String>"
+      },
+      {
+        "name": "image",
+        "type": "List<String>"
+      },
+      {
+        "name": "unknown",
+        "type": "List<String>"
+      },
+      {
+        "name": "video",
+        "type": "List<String>"
+      },
+      {
+        "name": "webpage",
+        "type": "List<String>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.OutputMeta",
+    "properties": [
+      {
+        "name": "colorspace",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "dominant_colors",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "has_transparency",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "mean_volume",
+        "type": "Nullable<Boolean>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.PaginatedImportRobotBase",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "files_per_page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "page_number",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "recursive",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.RobotBase",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.SmartCdn.FileServeRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "headers",
+        "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.SmartCdn.TlcdnDeliverRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.StoreRobotBase",
+    "properties": [
+      {
+        "name": "credentials",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "path",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.UploadHandleRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.VideoEncoding.VideoAdaptiveRobot",
+    "properties": [
+      {
+        "name": "closed_captions",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "playlist_name",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "segment_duration",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "technique",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.VideoEncoding.VideoArtworkRobot",
+    "properties": [
+      {
+        "name": "ffmpeg",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "method",
+        "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.VideoEncoding.VideoConcatenateRobot",
+    "properties": [
+      {
+        "name": "audio_fade_seconds",
+        "type": "Nullable<Double>"
+      },
+      {
+        "name": "ffmpeg",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "video_fade_seconds",
+        "type": "Nullable<Double>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.VideoEncoding.VideoEncodeRobot",
+    "properties": [
+      {
+        "name": "background",
+        "type": "String"
+      },
+      {
+        "name": "chunk_duration",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "crop",
+        "type": "AnyOf<String, Crop>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "ffmpeg",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "freeze_detect",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "height",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "hint",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "resize_strategy",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "rotate",
+        "type": "AnyOf<Boolean, Int32>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "turbo",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "width",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "zoom",
+        "type": "Nullable<Boolean>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.VideoEncoding.VideoMergeRobot",
+    "properties": [
+      {
+        "name": "audio_delay",
+        "type": "Nullable<Double>"
+      },
+      {
+        "name": "background",
+        "type": "String"
+      },
+      {
+        "name": "duration",
+        "type": "Nullable<Double>"
+      },
+      {
+        "name": "ffmpeg",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "framerate",
+        "type": "String"
+      },
+      {
+        "name": "height",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "image_durations",
+        "type": "List<Double>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "replace_audio",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "resize_strategy",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "vstack",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "width",
+        "type": "Nullable<Int32>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.VideoEncoding.VideoOndemandRobot",
+    "properties": [
+      {
+        "name": "asset",
+        "type": "String"
+      },
+      {
+        "name": "asset_param_name",
+        "type": "String"
+      },
+      {
+        "name": "enabled_variants",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "segment_duration",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "sign_urls_for",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "variants",
+        "type": "Dictionary<String, VideoOndemandVariant>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.VideoEncoding.VideoOndemandVariant",
+    "properties": [
+      {
+        "name": "ffmpeg",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "height",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "width",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.VideoEncoding.VideoSplitRobot",
+    "properties": [
+      {
+        "name": "ffmpeg",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "height",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "segments",
+        "type": "List<VideoSplitSegment>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "width",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.VideoEncoding.VideoSplitSegment",
+    "properties": [
+      {
+        "name": "from",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "to",
+        "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.VideoEncoding.VideoSubtitleRobot",
+    "properties": [
+      {
+        "name": "border_color",
+        "type": "String"
+      },
+      {
+        "name": "border_style",
+        "type": "String"
+      },
+      {
+        "name": "ffmpeg",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "font",
+        "type": "String"
+      },
+      {
+        "name": "font_color",
+        "type": "String"
+      },
+      {
+        "name": "font_size",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "position",
+        "type": "String"
+      },
+      {
+        "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "subtitles_type",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.VideoEncoding.VideoThumbnailsRobot",
+    "properties": [
+      {
+        "name": "background",
+        "type": "String"
+      },
+      {
+        "name": "count",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "ffmpeg_stack",
+        "type": "String"
+      },
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "format",
+        "type": "String"
+      },
+      {
+        "name": "height",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "offsets",
+        "type": "AnyOf<List<Int32>, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "resize_strategy",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "rotate",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "width",
+        "type": "Nullable<Int32>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Templates.DeleteTemplateResponse",
+    "properties": [
+      {
+        "name": "error",
+        "type": "String"
+      },
+      {
+        "name": "http_code",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "ok",
+        "type": "String"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Templates.TemplateContent",
+    "properties": [
+      {
+        "name": "steps",
+        "type": "Dictionary<String, Dictionary<String, Object>>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Templates.TemplateListRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "fromdate",
+        "type": "Nullable<DateTime>",
+        "converter": "PaginationDateTimeConverter"
+      },
+      {
+        "name": "keywords",
+        "type": "List<String>"
+      },
+      {
+        "name": "order",
+        "type": "String"
+      },
+      {
+        "name": "page",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "pagesize",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "sort",
+        "type": "String"
+      },
+      {
+        "name": "todate",
+        "type": "Nullable<DateTime>",
+        "converter": "PaginationDateTimeConverter"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Templates.TemplateModel",
+    "properties": [
+      {
+        "name": "assembly_status_expiry",
+        "type": "String"
+      },
+      {
+        "name": "content",
+        "type": "TemplateContent"
+      },
+      {
+        "name": "created",
+        "type": "DateTimeOffset"
+      },
+      {
+        "name": "encryption_version",
+        "type": "Int32"
+      },
+      {
+        "name": "id",
+        "type": "String"
+      },
+      {
+        "name": "last_used",
+        "type": "Nullable<DateTimeOffset>"
+      },
+      {
+        "name": "modified",
+        "type": "DateTimeOffset"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "require_signature_auth",
+        "type": "Boolean",
+        "converter": "BooleanToIntConverter"
+      },
+      {
+        "name": "transcoding_result_expiry",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Templates.TemplateRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "require_signature_auth",
+        "type": "Boolean",
+        "converter": "BooleanToIntConverter"
+      },
+      {
+        "name": "template",
+        "type": "TemplateRequestContent"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Templates.TemplateRequestContent",
+    "properties": [
+      {
+        "name": "allow_steps_override",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "fields",
+        "type": "Dictionary<String, Object>"
+      },
+      {
+        "name": "notify_url",
+        "type": "String"
+      },
+      {
+        "name": "quiet",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "steps",
+        "type": "Dictionary<String, RobotBase>"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Templates.TemplateResponse",
+    "properties": [
+      {
+        "name": "assembly_status_expiry",
+        "type": "String"
+      },
+      {
+        "name": "content",
+        "type": "TemplateContent"
+      },
+      {
+        "name": "error",
+        "type": "String"
+      },
+      {
+        "name": "http_code",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "id",
+        "type": "String"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "ok",
+        "type": "String"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      },
+      {
+        "name": "require_signature_auth",
+        "type": "Boolean",
+        "converter": "BooleanToIntConverter"
+      },
+      {
+        "name": "transcoding_result_expiry",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Tokens.TokenRequest",
+    "properties": [
+      {
+        "name": "aud",
+        "type": "String"
+      },
+      {
+        "name": "grant_type",
+        "type": "String"
+      },
+      {
+        "name": "scope",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Tokens.TokenResponse",
+    "properties": [
+      {
+        "name": "access_token",
+        "type": "String"
+      },
+      {
+        "name": "error",
+        "type": "String"
+      },
+      {
+        "name": "expires_in",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "http_code",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "ok",
+        "type": "String"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      },
+      {
+        "name": "scope",
+        "type": "String"
+      },
+      {
+        "name": "token_type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.TransloaditResponse",
+    "properties": [
+      {
+        "name": "content",
+        "type": "String"
+      },
+      {
+        "name": "headers",
+        "type": "HttpResponseHeaders"
+      },
+      {
+        "name": "status_code",
+        "type": "HttpStatusCode"
+      }
+    ]
+  }
+]

--- a/tests/Transloadit.Tests/Tests/Constants/ConstantsTests.cs
+++ b/tests/Transloadit.Tests/Tests/Constants/ConstantsTests.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Constants
+{
+    // reflection-driven coverage over the public constant classes: every string
+    // constant must be non-empty. cheaply guards against blank/placeholder values.
+    public class ConstantsTests
+    {
+        public static IEnumerable<object[]> ConstantClassNames()
+        {
+            return typeof(TransloaditClient).Assembly
+                .GetTypes()
+                .Where(t => t.Namespace == "Transloadit.Constants"
+                    && t.IsPublic
+                    && t.IsAbstract
+                    && t.IsSealed) // static class
+                .Select(t => new object[] { t.FullName });
+        }
+
+        [Theory]
+        [MemberData(nameof(ConstantClassNames))]
+        public void StringConstants_AreNonEmpty(string typeName)
+        {
+            var type = typeof(TransloaditClient).Assembly.GetType(typeName, throwOnError: true);
+
+            var stringConstants = type
+                .GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string));
+
+            foreach (var field in stringConstants)
+            {
+                var value = (string)field.GetRawConstantValue();
+                Assert.False(string.IsNullOrEmpty(value), $"{typeName}.{field.Name} must be non-empty");
+            }
+        }
+
+        [Fact]
+        public void Discovers_ConstantClasses()
+        {
+            Assert.NotEmpty(ConstantClassNames());
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Models/CredentialsSerializationSmokeTests.cs
+++ b/tests/Transloadit.Tests/Tests/Models/CredentialsSerializationSmokeTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Transloadit.Models.Credentials;
+using Transloadit.Serialization;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Models
+{
+    // reflection-driven coverage over every concrete credentials request that has a
+    // parameterless constructor: instantiate, serialize, and assert the type discriminator.
+    public class CredentialsSerializationSmokeTests
+    {
+        public static IEnumerable<object[]> CredentialsTypeNames()
+        {
+            return ConcreteCredentialsTypes().Select(t => new object[] { t.FullName });
+        }
+
+        [Theory]
+        [MemberData(nameof(CredentialsTypeNames))]
+        public void Credentials_Serializes_WithTypeDiscriminator(string typeName)
+        {
+            var type = typeof(TransloaditClient).Assembly.GetType(typeName, throwOnError: true);
+            var credentials = (CredentialsRequestBase)Activator.CreateInstance(type);
+
+            var json = JsonConvert.SerializeObject(credentials, TransloaditSerializerSettings.CreateDefault());
+            var parsed = JObject.Parse(json);
+
+            Assert.False(string.IsNullOrEmpty(credentials.Type));
+            Assert.Equal(credentials.Type, (string)parsed["type"]);
+        }
+
+        [Fact]
+        public void Discovers_ManyCredentialsTypes()
+        {
+            var count = ConcreteCredentialsTypes().Count();
+            Assert.True(count >= 10, $"expected many credentials types, found {count}");
+        }
+
+        private static IEnumerable<Type> ConcreteCredentialsTypes()
+        {
+            return typeof(TransloaditClient).Assembly
+                .GetTypes()
+                .Where(t => typeof(CredentialsRequestBase).IsAssignableFrom(t)
+                    && !t.IsAbstract
+                    && t.GetConstructor(Type.EmptyTypes) != null);
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Models/GenericCredentialsRequestTests.cs
+++ b/tests/Transloadit.Tests/Tests/Models/GenericCredentialsRequestTests.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Transloadit.Models.Credentials;
+using Transloadit.Serialization;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Models
+{
+    // GenericCredentialsRequest has no parameterless ctor, so the reflection smoke
+    // test skips it; cover it explicitly here.
+    public class GenericCredentialsRequestTests
+    {
+        [Fact]
+        public void Serializes_TypeNameAndContent()
+        {
+            var credentials = new GenericCredentialsRequest("mytype")
+            {
+                Name = "cred-name",
+                Content = new Dictionary<string, string> { ["key"] = "value" },
+            };
+
+            var json = JsonConvert.SerializeObject(credentials, TransloaditSerializerSettings.CreateDefault());
+            var parsed = JObject.Parse(json);
+
+            Assert.Equal("mytype", (string)parsed["type"]);
+            Assert.Equal("cred-name", (string)parsed["name"]);
+            Assert.Equal("value", (string)parsed["content"]["key"]);
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Models/ModelSerializationSnapshotTests.cs
+++ b/tests/Transloadit.Tests/Tests/Models/ModelSerializationSnapshotTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Transloadit.Models;
+using Transloadit.Serialization;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Models
+{
+    // characterization (golden-snapshot) test that pins the serialization contract shape of
+    // every class under Models to a committed file. any future change that alters how a class
+    // serializes (renamed/added/removed property, changed type, added/removed converter) fails
+    // this test until the snapshot is intentionally regenerated with UPDATE_SNAPSHOTS=1.
+    public class ModelSerializationSnapshotTests
+    {
+        [Fact]
+        public void ModelsSerializationContract_MatchesSnapshot()
+        {
+            var snapshot = BuildSnapshot(out var typeCount);
+
+            // guard so a broken discovery can't silently blank the snapshot in update mode
+            Assert.True(typeCount > 120, $"expected many model types, discovered {typeCount}");
+
+            var path = SnapshotPath();
+
+            if (Environment.GetEnvironmentVariable("UPDATE_SNAPSHOTS") == "1")
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                File.WriteAllText(path, snapshot);
+                return;
+            }
+
+            Assert.True(File.Exists(path),
+                $"snapshot file not found at {path}. regenerate it with UPDATE_SNAPSHOTS=1.");
+
+            var expected = Normalize(File.ReadAllText(path));
+            var actual = Normalize(snapshot);
+            Assert.Equal(expected, actual);
+        }
+
+        private static string BuildSnapshot(out int typeCount)
+        {
+            var settings = TransloaditSerializerSettings.CreateDefault();
+            var resolver = (DefaultContractResolver)settings.ContractResolver;
+
+            var types = typeof(TransloaditClient).Assembly
+                .GetTypes()
+                .Where(IsSnapshotType)
+                .OrderBy(t => t.FullName, StringComparer.Ordinal)
+                .ToList();
+
+            typeCount = types.Count;
+
+            var models = new List<ModelContract>();
+            foreach (var type in types)
+            {
+                var properties = new List<PropertyContract>();
+                if (resolver.ResolveContract(type) is JsonObjectContract objectContract)
+                {
+                    foreach (var property in objectContract.Properties)
+                    {
+                        if (property.Ignored)
+                        {
+                            continue;
+                        }
+
+                        properties.Add(new PropertyContract
+                        {
+                            Name = property.PropertyName,
+                            Type = FriendlyTypeName(property.PropertyType),
+                            Converter = EffectiveConverter(property, settings.Converters),
+                        });
+                    }
+
+                    properties = properties.OrderBy(p => p.Name, StringComparer.Ordinal).ToList();
+                }
+
+                models.Add(new ModelContract { Type = type.FullName, Properties = properties });
+            }
+
+            var snapshotSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
+            return JsonConvert.SerializeObject(models, Formatting.Indented, snapshotSettings);
+        }
+
+        private static bool IsSnapshotType(Type type)
+        {
+            return type.IsClass
+                && !type.IsGenericTypeDefinition
+                && (type.Namespace == "Transloadit.Models"
+                    || (type.Namespace != null && type.Namespace.StartsWith("Transloadit.Models.")))
+                // AnyOf unions serialize via the settings-level AnyOfConverter, not an object contract
+                && !typeof(AnyOf).IsAssignableFrom(type)
+                // skip compiler-generated closures/state machines
+                && !type.Name.Contains("<");
+        }
+
+        private static string EffectiveConverter(JsonProperty property, IList<JsonConverter> settingsConverters)
+        {
+            if (property.Converter != null)
+            {
+                return property.Converter.GetType().Name;
+            }
+
+            foreach (var converter in settingsConverters)
+            {
+                if (converter.CanConvert(property.PropertyType))
+                {
+                    return converter.GetType().Name;
+                }
+            }
+
+            return null;
+        }
+
+        private static string FriendlyTypeName(Type type)
+        {
+            var underlying = Nullable.GetUnderlyingType(type);
+            if (underlying != null)
+            {
+                return $"Nullable<{FriendlyTypeName(underlying)}>";
+            }
+
+            if (type.IsArray)
+            {
+                return $"{FriendlyTypeName(type.GetElementType())}[]";
+            }
+
+            if (type.IsGenericType)
+            {
+                var name = type.Name;
+                var tick = name.IndexOf('`');
+                if (tick >= 0)
+                {
+                    name = name.Substring(0, tick);
+                }
+
+                var args = type.GetGenericArguments().Select(FriendlyTypeName);
+                return $"{name}<{string.Join(", ", args)}>";
+            }
+
+            return type.Name;
+        }
+
+        private static string Normalize(string value)
+            => value.Replace("\r\n", "\n").Replace("\r", "\n").TrimEnd('\n');
+
+        private static string SnapshotPath([CallerFilePath] string thisFile = null)
+        {
+            // this file lives in tests/Transloadit.Tests/Tests/Models; the snapshot lives in
+            // tests/Transloadit.Tests/Snapshots (two directories up).
+            var dir = Path.GetDirectoryName(thisFile);
+            return Path.GetFullPath(Path.Combine(dir, "..", "..", "Snapshots", "models.serialization.snapshot.json"));
+        }
+
+        private sealed class ModelContract
+        {
+            [JsonProperty("type")]
+            public string Type { get; set; }
+
+            [JsonProperty("properties")]
+            public List<PropertyContract> Properties { get; set; }
+        }
+
+        private sealed class PropertyContract
+        {
+            [JsonProperty("name")]
+            public string Name { get; set; }
+
+            [JsonProperty("type")]
+            public string Type { get; set; }
+
+            [JsonProperty("converter")]
+            public string Converter { get; set; }
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Models/RobotSerializationSmokeTests.cs
+++ b/tests/Transloadit.Tests/Tests/Models/RobotSerializationSmokeTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Transloadit.Models.Robots;
+using Transloadit.Serialization;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Models
+{
+    // reflection-driven coverage over every concrete robot in the library assembly:
+    // instantiate, serialize with the default settings, and assert the robot key is emitted.
+    // this keeps coverage broad and fails automatically if a new robot breaks serialization.
+    public class RobotSerializationSmokeTests
+    {
+        public static IEnumerable<object[]> RobotTypeNames()
+        {
+            return ConcreteRobotTypes().Select(t => new object[] { t.FullName });
+        }
+
+        [Theory]
+        [MemberData(nameof(RobotTypeNames))]
+        public void Robot_Serializes_WithMatchingRobotKey(string typeName)
+        {
+            var type = typeof(TransloaditClient).Assembly.GetType(typeName, throwOnError: true);
+            var robot = (RobotBase)Activator.CreateInstance(type);
+
+            var json = JsonConvert.SerializeObject(robot, TransloaditSerializerSettings.CreateDefault());
+            var parsed = JObject.Parse(json);
+
+            Assert.Equal(robot.Robot, (string)parsed["robot"]);
+        }
+
+        [Fact]
+        public void Discovers_ManyRobots()
+        {
+            var count = ConcreteRobotTypes().Count();
+            Assert.True(count >= 80, $"expected the library to expose many robots, found {count}");
+        }
+
+        private static IEnumerable<Type> ConcreteRobotTypes()
+        {
+            return typeof(TransloaditClient).Assembly
+                .GetTypes()
+                .Where(t => typeof(RobotBase).IsAssignableFrom(t)
+                    && !t.IsAbstract
+                    && t.GetConstructor(Type.EmptyTypes) != null);
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Unit/AnyOfTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/AnyOfTests.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using Transloadit.Models;
+using Transloadit.Models.Robots;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Unit
+{
+    public class AnyOfTests
+    {
+        [Fact]
+        public void TwoArg_FirstType_ExposesValueAndType()
+        {
+            AnyOf<string, List<string>> anyOf = "hello";
+
+            Assert.Equal("hello", anyOf.Value);
+            Assert.Equal(typeof(string), anyOf.Type);
+
+            string asString = anyOf;
+            Assert.Equal("hello", asString);
+        }
+
+        [Fact]
+        public void TwoArg_SecondType_ExposesValueAndType()
+        {
+            var list = new List<string> { "a", "b" };
+            AnyOf<string, List<string>> anyOf = list;
+
+            Assert.Same(list, anyOf.Value);
+            Assert.Equal(typeof(List<string>), anyOf.Type);
+
+            List<string> asList = anyOf;
+            Assert.Same(list, asList);
+        }
+
+        [Fact]
+        public void TwoArg_ConvertingToWrongType_ReturnsDefault()
+        {
+            AnyOf<string, List<string>> anyOf = "hello";
+
+            // the outbound operator returns the backing field regardless of which case is set
+            List<string> asList = anyOf;
+            Assert.Null(asList);
+        }
+
+        [Fact]
+        public void TwoArg_NullValue_ImplicitlyConvertsToNull()
+        {
+            AnyOf<string, List<string>> anyOf = (string)null;
+            Assert.Null(anyOf);
+        }
+
+        [Fact]
+        public void ThreeArg_SelectsCorrectCase()
+        {
+            AnyOf<string, List<string>, AdvancedUse> first = "s";
+            AnyOf<string, List<string>, AdvancedUse> second = new List<string> { "x" };
+            AnyOf<string, List<string>, AdvancedUse> third = new AdvancedUse();
+
+            Assert.Equal(typeof(string), first.Type);
+            Assert.Equal(typeof(List<string>), second.Type);
+            Assert.Equal(typeof(AdvancedUse), third.Type);
+
+            Assert.Equal("s", first.Value);
+            Assert.IsType<List<string>>(second.Value);
+            Assert.IsType<AdvancedUse>(third.Value);
+        }
+
+        [Fact]
+        public void ThreeArg_NullValue_ImplicitlyConvertsToNull()
+        {
+            AnyOf<string, List<string>, AdvancedUse> anyOf = (AdvancedUse)null;
+            Assert.Null(anyOf);
+        }
+
+        [Fact]
+        public void ThreeArg_OutboundOperators_ReturnBackingValues()
+        {
+            var list = new List<string> { "x" };
+            var advanced = new AdvancedUse();
+
+            AnyOf<string, List<string>, AdvancedUse> first = "s";
+            AnyOf<string, List<string>, AdvancedUse> second = list;
+            AnyOf<string, List<string>, AdvancedUse> third = advanced;
+
+            string asString = first;
+            List<string> asList = second;
+            AdvancedUse asAdvanced = third;
+
+            Assert.Equal("s", asString);
+            Assert.Same(list, asList);
+            Assert.Same(advanced, asAdvanced);
+        }
+
+        [Fact]
+        public void TwoArg_Value_ReflectsSecondCase()
+        {
+            var list = new List<string> { "x" };
+            AnyOf<string, List<string>> anyOf = list;
+
+            Assert.Equal(typeof(List<string>), anyOf.Type);
+            Assert.Same(list, anyOf.Value);
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Unit/AssemblyTrackerOfflineTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/AssemblyTrackerOfflineTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading.Tasks;
+using Transloadit.Constants;
+using Transloadit.Tests.Infrastructure;
+using Transloadit.Utilities;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Unit
+{
+    public class AssemblyTrackerOfflineTests
+    {
+        private const string Executing = "{\"ok\":\"ASSEMBLY_EXECUTING\",\"assembly_id\":\"abc\"}";
+        private const string Completed = "{\"ok\":\"ASSEMBLY_COMPLETED\",\"assembly_id\":\"abc\"}";
+
+        [Fact]
+        public async Task WaitCompletionAsync_PollsUntilCompleted()
+        {
+            // first poll returns executing, subsequent polls return completed
+            var handler = FakeHttpMessageHandler.Sequence(Executing, Completed);
+            var client = TestClientFactory.Create(handler);
+            var tracker = new AssemblyTracker(client);
+
+            var completed = await tracker.WaitCompletionAsync("abc", millisecondsDelay: 1);
+
+            Assert.Equal(ResponseCodes.AssemblyCompleted, completed.Base.Ok);
+            Assert.True(handler.CallCount >= 2);
+        }
+
+        [Fact]
+        public async Task WaitCompletionAsync_WhenNeverCompletes_TimesOut()
+        {
+            // always executing, so the tracker keeps polling until the timeout cancels it
+            var handler = FakeHttpMessageHandler.Json(Executing);
+            var client = TestClientFactory.Create(handler);
+            var tracker = new AssemblyTracker(client, new AssemblyTrackerOptions { WaitCompletionTimeout = 50 });
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => tracker.WaitCompletionAsync("abc", millisecondsDelay: 20));
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Unit/BaseParamsUnitTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/BaseParamsUnitTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Transloadit.Models;
+using Transloadit.Serialization;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Unit
+{
+    public class BaseParamsUnitTests
+    {
+        [Fact]
+        public void EnableSignatureAuth_DefaultsToTrue()
+        {
+            var parameters = new BaseParams();
+            Assert.True(parameters.EnableSignatureAuth);
+        }
+
+        [Fact]
+        public void DisableSignatureAuth_SetsFlagFalse()
+        {
+            var parameters = new BaseParams();
+            parameters.DisableSignatureAuth();
+            Assert.False(parameters.EnableSignatureAuth);
+        }
+
+        [Fact]
+        public void SetAuth_StoresAuthParams()
+        {
+            var parameters = new BaseParams();
+            var auth = new AuthParams { Key = "k" };
+
+            parameters.SetAuth(auth);
+
+            Assert.Same(auth, parameters.Auth);
+        }
+
+        [Fact]
+        public void AuthParams_Serializes_WithSnakeCaseAndDateFormat()
+        {
+            var auth = new AuthParams
+            {
+                Key = "k",
+                Expires = new DateTime(2025, 2, 20, 1, 52, 4, DateTimeKind.Utc),
+                MaxSize = 100,
+            };
+
+            var json = JsonConvert.SerializeObject(auth, TransloaditSerializerSettings.CreateDefault());
+            var parsed = JObject.Parse(json);
+
+            Assert.Equal("k", (string)parsed["key"]);
+            Assert.Equal("2025/02/20 01:52:04+00:00", (string)parsed["expires"]);
+            Assert.Equal(100, (int)parsed["max_size"]);
+            // NullValueHandling.Ignore drops unset properties
+            Assert.Null(parsed["nonce"]);
+            Assert.Null(parsed["referer"]);
+        }
+
+        [Fact]
+        public void PaginationParams_Serializes_WithSnakeCaseAndDateFormat()
+        {
+            var pagination = new PaginationParams
+            {
+                Page = 2,
+                PageSize = 10,
+                FromDate = new DateTime(2025, 2, 20, 1, 52, 4, DateTimeKind.Utc),
+                Keywords = new List<string> { "alpha" },
+            };
+
+            var json = JsonConvert.SerializeObject(pagination, TransloaditSerializerSettings.CreateDefault());
+            var parsed = JObject.Parse(json);
+
+            Assert.Equal(2, (int)parsed["page"]);
+            Assert.Equal(10, (int)parsed["pagesize"]);
+            Assert.Equal("2025-02-20 01:52:04", (string)parsed["fromdate"]);
+            Assert.Equal("alpha", (string)parsed["keywords"][0]);
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Unit/ResponseBaseTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/ResponseBaseTests.cs
@@ -1,0 +1,67 @@
+using System.Net;
+using System.Net.Http;
+using Newtonsoft.Json;
+using Transloadit.Models;
+using Transloadit.Serialization;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Unit
+{
+    public class ResponseBaseTests
+    {
+        [Fact]
+        public void IsSuccessResponse_WhenOkPresent_ReturnsTrue()
+        {
+            var response = new ResponseBase();
+            response.Base.Ok = "OK";
+            Assert.True(response.IsSuccessResponse());
+        }
+
+        [Fact]
+        public void IsSuccessResponse_WhenNeitherOkNorError_ReturnsTrue()
+        {
+            var response = new ResponseBase();
+            Assert.True(response.IsSuccessResponse());
+        }
+
+        [Fact]
+        public void IsSuccessResponse_WhenErrorPresentAndNoOk_ReturnsFalse()
+        {
+            var response = new ResponseBase();
+            response.Base.Error = "SOME_ERROR";
+            Assert.False(response.IsSuccessResponse());
+        }
+
+        [Fact]
+        public void IsSuccessResponse_WhenBothOkAndError_ReturnsTrue()
+        {
+            var response = new ResponseBase();
+            response.Base.Ok = "OK";
+            response.Base.Error = "SOME_ERROR";
+            Assert.True(response.IsSuccessResponse());
+        }
+
+        [Fact]
+        public void TransloaditResponse_ExposesConstructorValues()
+        {
+            using var message = new HttpResponseMessage(HttpStatusCode.Accepted);
+            var raw = new TransloaditResponse(HttpStatusCode.Accepted, message.Headers, "body");
+
+            Assert.Equal(HttpStatusCode.Accepted, raw.StatusCode);
+            Assert.Equal("body", raw.Content);
+            Assert.NotNull(raw.Headers);
+        }
+
+        [Fact]
+        public void PaginatedListResponse_DeserializesCountAndItems()
+        {
+            const string json = "{\"ok\":\"OK\",\"count\":2,\"items\":[1,2]}";
+            var response = JsonConvert.DeserializeObject<PaginatedListResponse<int>>(
+                json, TransloaditSerializerSettings.CreateDefault());
+
+            Assert.Equal(2, response.Count);
+            Assert.Equal(new[] { 1, 2 }, response.Items);
+            Assert.True(response.IsSuccessResponse());
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Unit/Serialization/AnyOfConverterTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/Serialization/AnyOfConverterTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using Transloadit.Models;
+using Transloadit.Serialization;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Unit.Serialization
+{
+    public class AnyOfConverterTests
+    {
+        [Fact]
+        public void WriteJson_FirstType_SerializesInnerValue()
+        {
+            AnyOf<string, List<string>> anyOf = "hello";
+            var json = JsonConvert.SerializeObject(anyOf, new AnyOfConverter());
+            Assert.Equal("\"hello\"", json);
+        }
+
+        [Fact]
+        public void WriteJson_SecondType_SerializesInnerValue()
+        {
+            AnyOf<string, List<string>> anyOf = new List<string> { "a", "b" };
+            var json = JsonConvert.SerializeObject(anyOf, new AnyOfConverter());
+            Assert.Equal("[\"a\",\"b\"]", json);
+        }
+
+        [Fact]
+        public void WriteJson_Null_WritesNull()
+        {
+            var converter = new AnyOfConverter();
+            using var writer = new StringWriter();
+            using (var jsonWriter = new JsonTextWriter(writer))
+            {
+                converter.WriteJson(jsonWriter, null, JsonSerializer.CreateDefault());
+            }
+
+            Assert.Equal("null", writer.ToString());
+        }
+
+        [Fact]
+        public void WriteJson_NonAnyOfValue_Throws()
+        {
+            var converter = new AnyOfConverter();
+            using var writer = new StringWriter();
+            using var jsonWriter = new JsonTextWriter(writer);
+
+            Assert.Throws<JsonSerializationException>(
+                () => converter.WriteJson(jsonWriter, "not an AnyOf", JsonSerializer.CreateDefault()));
+        }
+
+        [Fact]
+        public void CanConvert_AnyOfTypes_ReturnsTrue()
+        {
+            var converter = new AnyOfConverter();
+            Assert.True(converter.CanConvert(typeof(AnyOf<string, List<string>>)));
+            Assert.False(converter.CanConvert(typeof(string)));
+        }
+
+        [Fact]
+        public void ReadJson_IsNotSupported()
+        {
+            var converter = new AnyOfConverter();
+            Assert.Throws<NotImplementedException>(
+                () => converter.ReadJson(null, typeof(AnyOf<string, List<string>>), null, JsonSerializer.CreateDefault()));
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Unit/Serialization/BooleanToIntConverterTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/Serialization/BooleanToIntConverterTests.cs
@@ -1,0 +1,48 @@
+using System.IO;
+using Newtonsoft.Json;
+using Transloadit.Serialization;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Unit.Serialization
+{
+    public class BooleanToIntConverterTests
+    {
+        [Theory]
+        [InlineData(true, "1")]
+        [InlineData(false, "0")]
+        public void WriteJson_WritesIntForBool(bool value, string expected)
+        {
+            var converter = new BooleanToIntConverter();
+            using var writer = new StringWriter();
+            using (var jsonWriter = new JsonTextWriter(writer))
+            {
+                converter.WriteJson(jsonWriter, value, JsonSerializer.CreateDefault());
+            }
+
+            Assert.Equal(expected, writer.ToString());
+        }
+
+        [Theory]
+        [InlineData("0", false)]
+        [InlineData("1", true)]
+        [InlineData("5", true)]
+        public void ReadJson_ConvertsIntToBool(string raw, bool expected)
+        {
+            var converter = new BooleanToIntConverter();
+            using var reader = new JsonTextReader(new StringReader(raw));
+            reader.Read();
+
+            var result = converter.ReadJson(reader, typeof(bool), null, JsonSerializer.CreateDefault());
+
+            Assert.Equal(expected, (bool)result);
+        }
+
+        [Fact]
+        public void CanConvert_OnlyBool()
+        {
+            var converter = new BooleanToIntConverter();
+            Assert.True(converter.CanConvert(typeof(bool)));
+            Assert.False(converter.CanConvert(typeof(int)));
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Unit/Serialization/DateTimeConvertersTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/Serialization/DateTimeConvertersTests.cs
@@ -1,0 +1,26 @@
+using System;
+using Newtonsoft.Json;
+using Transloadit.Serialization;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Unit.Serialization
+{
+    public class DateTimeConvertersTests
+    {
+        private static readonly DateTime SampleUtc = new DateTime(2025, 2, 20, 1, 52, 4, DateTimeKind.Utc);
+
+        [Fact]
+        public void AuthExpiresConverter_UsesTransloaditFormat()
+        {
+            var json = JsonConvert.SerializeObject(SampleUtc, new AuthExpiresDateTimeConverter());
+            Assert.Equal("\"2025/02/20 01:52:04+00:00\"", json);
+        }
+
+        [Fact]
+        public void PaginationConverter_UsesSpaceSeparatedFormat()
+        {
+            var json = JsonConvert.SerializeObject(SampleUtc, new PaginationDateTimeConverter());
+            Assert.Equal("\"2025-02-20 01:52:04\"", json);
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Unit/ServiceEndpointTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/ServiceEndpointTests.cs
@@ -1,0 +1,135 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Transloadit.Models.Credentials;
+using Transloadit.Models.Templates;
+using Transloadit.Tests.Infrastructure;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Unit
+{
+    // exercises each service's endpoint mapping (verb + path) through the fake handler,
+    // so the SendRequest delegation is covered without live credentials
+    public class ServiceEndpointTests
+    {
+        private const string Ok = "{\"ok\":\"OK\"}";
+        private const string OkList = "{\"ok\":\"OK\",\"count\":0,\"items\":[]}";
+
+        [Fact]
+        public async Task Billing_Get_MapsToBillEndpoint()
+        {
+            var handler = FakeHttpMessageHandler.Json(Ok);
+            var client = TestClientFactory.Create(handler);
+
+            await client.Billing.GetAsync(2025, 2);
+
+            Assert.Equal(HttpMethod.Get, handler.LastMethod);
+            Assert.Equal("/bill/2025-02", handler.LastRequestUri.AbsolutePath);
+        }
+
+        [Fact]
+        public async Task Queues_GetJobSlots_MapsToQueuesEndpoint()
+        {
+            var handler = FakeHttpMessageHandler.Json(Ok);
+            var client = TestClientFactory.Create(handler);
+
+            await client.Queues.GetJobSlotsAsync();
+
+            Assert.Equal(HttpMethod.Get, handler.LastMethod);
+            Assert.Equal("/queues/job_slots", handler.LastRequestUri.AbsolutePath);
+        }
+
+        [Fact]
+        public async Task AssemblyNotifications_Replay_MapsToReplayEndpoint()
+        {
+            var handler = FakeHttpMessageHandler.Json(Ok);
+            var client = TestClientFactory.Create(handler);
+
+            await client.AssemblyNotifications.ReplayAsync("a1");
+
+            Assert.Equal(HttpMethod.Post, handler.LastMethod);
+            Assert.Equal("/assembly_notifications/a1/replay", handler.LastRequestUri.AbsolutePath);
+        }
+
+        [Theory]
+        [InlineData("get")]
+        [InlineData("list")]
+        [InlineData("create")]
+        [InlineData("update")]
+        [InlineData("delete")]
+        public async Task Templates_Methods_MapToTemplatesEndpoints(string operation)
+        {
+            var handler = FakeHttpMessageHandler.Json(operation == "list" ? OkList : Ok);
+            var client = TestClientFactory.Create(handler);
+
+            switch (operation)
+            {
+                case "get":
+                    await client.Templates.GetAsync("t1");
+                    Assert.Equal(HttpMethod.Get, handler.LastMethod);
+                    Assert.Equal("/templates/t1", handler.LastRequestUri.AbsolutePath);
+                    break;
+                case "list":
+                    await client.Templates.GetListAsync();
+                    Assert.Equal(HttpMethod.Get, handler.LastMethod);
+                    Assert.Equal("/templates", handler.LastRequestUri.AbsolutePath);
+                    break;
+                case "create":
+                    await client.Templates.CreateAsync(new TemplateRequest { Name = "n" });
+                    Assert.Equal(HttpMethod.Post, handler.LastMethod);
+                    Assert.Equal("/templates", handler.LastRequestUri.AbsolutePath);
+                    break;
+                case "update":
+                    await client.Templates.UpdateAsync("t1", new TemplateRequest { Name = "n" });
+                    Assert.Equal(HttpMethod.Put, handler.LastMethod);
+                    Assert.Equal("/templates/t1", handler.LastRequestUri.AbsolutePath);
+                    break;
+                case "delete":
+                    await client.Templates.DeleteAsync("t1");
+                    Assert.Equal(HttpMethod.Delete, handler.LastMethod);
+                    Assert.Equal("/templates/t1", handler.LastRequestUri.AbsolutePath);
+                    break;
+            }
+        }
+
+        [Theory]
+        [InlineData("get")]
+        [InlineData("list")]
+        [InlineData("create")]
+        [InlineData("update")]
+        [InlineData("delete")]
+        public async Task Credentials_Methods_MapToCredentialsEndpoints(string operation)
+        {
+            var handler = FakeHttpMessageHandler.Json(operation == "list" ? OkList : Ok);
+            var client = TestClientFactory.Create(handler);
+
+            switch (operation)
+            {
+                case "get":
+                    await client.Credentials.GetAsync("c1");
+                    Assert.Equal(HttpMethod.Get, handler.LastMethod);
+                    Assert.Equal("/template_credentials/c1", handler.LastRequestUri.AbsolutePath);
+                    break;
+                case "list":
+                    await client.Credentials.GetListAsync();
+                    Assert.Equal(HttpMethod.Get, handler.LastMethod);
+                    Assert.Equal("/template_credentials", handler.LastRequestUri.AbsolutePath);
+                    break;
+                case "create":
+                    await client.Credentials.CreateAsync(new S3CredentialsRequest { Name = "n" });
+                    Assert.Equal(HttpMethod.Post, handler.LastMethod);
+                    Assert.Equal("/template_credentials", handler.LastRequestUri.AbsolutePath);
+                    break;
+                case "update":
+                    await client.Credentials.UpdateAsync("c1", new S3CredentialsRequest { Name = "n" });
+                    Assert.Equal(HttpMethod.Put, handler.LastMethod);
+                    Assert.Equal("/template_credentials/c1", handler.LastRequestUri.AbsolutePath);
+                    break;
+                case "delete":
+                    await client.Credentials.DeleteAsync("c1");
+                    Assert.Equal(HttpMethod.Delete, handler.LastMethod);
+                    Assert.Equal("/template_credentials/c1", handler.LastRequestUri.AbsolutePath);
+                    break;
+            }
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Unit/SignatureUtilitiesTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/SignatureUtilitiesTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.ComponentModel;
+using Transloadit.Services;
+using Transloadit.Utilities;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Unit
+{
+    public class SignatureUtilitiesTests
+    {
+        private const string Key = "ZAoE63deFCA915LupzPqTyOv4WCZmuOwJioIxwF3";
+        private const string Input = "{\"auth\":{\"key\":\"some-secret-key\"}}";
+
+        [Fact]
+        public void CalculateSignature_Sha384_HasPrefix()
+        {
+            var signature = SignatureUtilities.CalculateSignature(Input, Key, SignatureAlgorithm.Sha384);
+            Assert.StartsWith("sha384:", signature);
+        }
+
+        [Fact]
+        public void CalculateSignature_Sha256_HasPrefix()
+        {
+            var signature = SignatureUtilities.CalculateSignature(Input, Key, SignatureAlgorithm.Sha256);
+            Assert.StartsWith("sha256:", signature);
+        }
+
+        [Fact]
+        public void CalculateSignature_Sha1_HasNoPrefix()
+        {
+            var signature = SignatureUtilities.CalculateSignature(Input, Key, SignatureAlgorithm.Sha1);
+            Assert.DoesNotContain(":", signature);
+        }
+
+        [Fact]
+        public void CalculateSignature_DefaultsToSha384()
+        {
+            var withDefault = SignatureUtilities.CalculateSignature(Input, Key);
+            var explicitSha384 = SignatureUtilities.CalculateSignature(Input, Key, SignatureAlgorithm.Sha384);
+            Assert.Equal(explicitSha384, withDefault);
+        }
+
+        [Fact]
+        public void CalculateSignature_UnknownAlgorithm_Throws()
+        {
+            Assert.Throws<InvalidEnumArgumentException>(
+                () => SignatureUtilities.CalculateSignature(Input, Key, (SignatureAlgorithm)999));
+        }
+
+        [Fact]
+        public void ValidateSignature_MatchingSignature_ReturnsTrue()
+        {
+            var signature = SignatureUtilities.CalculateSignature(Input, Key, SignatureAlgorithm.Sha384);
+            Assert.True(SignatureUtilities.ValidateSignature(Input, Key, signature));
+        }
+
+        [Fact]
+        public void ValidateSignature_NonMatchingSignature_ReturnsFalse()
+        {
+            Assert.False(SignatureUtilities.ValidateSignature(Input, Key, "sha384:deadbeef"));
+        }
+
+        [Fact]
+        public void ValidateSignature_LegacySha1_ReturnsTrue()
+        {
+            var sha1 = SignatureUtilities.CalculateSignature(Input, Key, SignatureAlgorithm.Sha1);
+            Assert.True(SignatureUtilities.ValidateSignature(Input, Key, sha1));
+        }
+
+        [Fact]
+        public void ValidateSignature_UnknownPrefix_Throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () => SignatureUtilities.ValidateSignature(Input, Key, "md5:abcdef"));
+        }
+
+        [Fact]
+        public void SignatureService_DelegatesToUtilities()
+        {
+            var service = new SignatureService(Key);
+            var fromService = service.CalculateSignature(Input, SignatureAlgorithm.Sha256);
+            var fromUtilities = SignatureUtilities.CalculateSignature(Input, Key, SignatureAlgorithm.Sha256);
+
+            Assert.Equal(fromUtilities, fromService);
+            Assert.True(service.ValidateSignature(Input, fromService));
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Unit/SmartCdnServiceTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/SmartCdnServiceTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using Transloadit.Services;
+using Transloadit.Utilities;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Unit
+{
+    public class SmartCdnServiceTests
+    {
+        private const string Key = "my-key";
+        private const string Secret = "my-secret";
+
+        // a fixed expiration keeps the produced url deterministic
+        private static readonly DateTimeOffset Expiration = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000);
+
+        [Fact]
+        public void GetSignedSmartCdnUrl_ProducesDeterministicSignedUrl()
+        {
+            var service = new SmartCdnService(Key, Secret);
+
+            var url = service.GetSignedSmartCdnUrl(
+                "ws",
+                "tpl",
+                "input",
+                Expiration,
+                new Dictionary<string, string> { ["width"] = "100" });
+
+            // params are sorted by key: auth_key, exp, width
+            const string query = "auth_key=my-key&exp=1700000000000&width=100";
+            var stringToSign = $"ws/tpl/input?{query}";
+            var expectedSignature = SignatureUtilities.CalculateSignature(stringToSign, Secret, SignatureAlgorithm.Sha256);
+
+            Assert.Equal($"https://ws.tlcdn.com/tpl/input?{query}&sig={expectedSignature}", url);
+        }
+
+        [Fact]
+        public void GetSignedSmartCdnUrl_UsesSha256Signature()
+        {
+            var service = new SmartCdnService(Key, Secret);
+            var url = service.GetSignedSmartCdnUrl("ws", "tpl", "input", Expiration);
+            Assert.Contains("&sig=sha256:", url);
+        }
+
+        [Fact]
+        public void GetSignedSmartCdnUrl_WorksWithoutExtraParameters()
+        {
+            var service = new SmartCdnService(Key, Secret);
+            var url = service.GetSignedSmartCdnUrl("ws", "tpl", "input", Expiration);
+
+            Assert.Contains("auth_key=my-key", url);
+            Assert.Contains("exp=1700000000000", url);
+        }
+
+        [Fact]
+        public void GetSignedSmartCdnUrl_UrlEncodesParameterValues()
+        {
+            var service = new SmartCdnService(Key, Secret);
+            var url = service.GetSignedSmartCdnUrl(
+                "ws",
+                "tpl",
+                "input",
+                Expiration,
+                new Dictionary<string, string> { ["path"] = "/a b" });
+
+            Assert.Contains("path=%2Fa+b", url);
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Tests/Unit/TransloaditClientPipelineTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/TransloaditClientPipelineTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Transloadit.Constants;
+using Transloadit.Models.Assemblies;
+using Transloadit.Tests.Infrastructure;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Unit
+{
+    public class TransloaditClientPipelineTests
+    {
+        private const string AssemblyJson = "{\"ok\":\"ASSEMBLY_COMPLETED\",\"assembly_id\":\"abc\"}";
+        private const string ListJson = "{\"ok\":\"ASSEMBLIES_FOUND\",\"count\":0,\"items\":[]}";
+
+        [Fact]
+        public async Task Get_UnsignedEndpoint_PutsParamsInQueryWithoutSignature()
+        {
+            var handler = FakeHttpMessageHandler.Json(AssemblyJson);
+            var client = TestClientFactory.Create(handler);
+
+            var response = await client.Assemblies.GetAsync("abc");
+
+            Assert.Equal(HttpMethod.Get, handler.LastMethod);
+            Assert.StartsWith("https://api.test/assemblies/abc?", handler.LastRequestUri.ToString());
+            Assert.Contains("params=", handler.LastRequestUri.Query);
+            Assert.DoesNotContain("signature=", handler.LastRequestUri.Query);
+            Assert.True(response.IsSuccessResponse());
+            Assert.Equal("abc", response.AssemblyId);
+        }
+
+        [Fact]
+        public async Task Get_SignedEndpoint_PutsSignatureInQuery()
+        {
+            var handler = FakeHttpMessageHandler.Json(ListJson);
+            var client = TestClientFactory.Create(handler);
+
+            await client.Assemblies.GetListAsync();
+
+            Assert.Contains("params=", handler.LastRequestUri.Query);
+            Assert.Contains("signature=", handler.LastRequestUri.Query);
+        }
+
+        [Fact]
+        public async Task Get_SignedEndpoint_WithoutSecret_OmitsSignature()
+        {
+            var handler = FakeHttpMessageHandler.Json(ListJson);
+            var client = TestClientFactory.Create(handler, withSecret: false);
+
+            await client.Assemblies.GetListAsync();
+
+            Assert.Contains("params=", handler.LastRequestUri.Query);
+            Assert.DoesNotContain("signature=", handler.LastRequestUri.Query);
+        }
+
+        [Fact]
+        public async Task Post_PutsParamsAndSignatureInMultipartBody()
+        {
+            var handler = FakeHttpMessageHandler.Json(AssemblyJson);
+            var client = TestClientFactory.Create(handler);
+
+            await client.Assemblies.CreateAsync(new AssemblyRequest { TemplateId = "tpl" });
+
+            Assert.Equal(HttpMethod.Post, handler.LastMethod);
+            Assert.Contains("template_id", handler.LastRequestContent);
+            Assert.Contains("params", handler.LastRequestContent);
+            Assert.Contains("signature", handler.LastRequestContent);
+        }
+
+        [Fact]
+        public async Task Request_SetsTransloaditClientHeader()
+        {
+            var handler = FakeHttpMessageHandler.Json(AssemblyJson);
+            var client = TestClientFactory.Create(handler);
+
+            await client.Assemblies.GetAsync("abc");
+
+            Assert.True(handler.LastRequest.Headers.Contains("Transloadit-Client"));
+            var value = string.Join(string.Empty, handler.LastRequest.Headers.GetValues("Transloadit-Client"));
+            Assert.Equal($"transloadit-sharp/{ClientVersion.Current}", value);
+        }
+
+        [Fact]
+        public async Task Response_AttachesRawTransloaditResponse()
+        {
+            var handler = FakeHttpMessageHandler.Json(AssemblyJson, HttpStatusCode.OK);
+            var client = TestClientFactory.Create(handler);
+
+            var response = await client.Assemblies.GetAsync("abc");
+
+            Assert.NotNull(response.TransloaditResponse);
+            Assert.Equal(HttpStatusCode.OK, response.TransloaditResponse.StatusCode);
+            Assert.Equal(AssemblyJson, response.TransloaditResponse.Content);
+        }
+
+        [Fact]
+        public async Task Token_UsesBasicAuthAndGrantType()
+        {
+            var handler = FakeHttpMessageHandler.Json(
+                "{\"access_token\":\"tok\",\"token_type\":\"Bearer\",\"expires_in\":3600}");
+            var client = TestClientFactory.Create(handler);
+
+            await client.Tokens.CreateAsync();
+
+            Assert.Equal(HttpMethod.Post, handler.LastMethod);
+            Assert.EndsWith("/token", handler.LastRequestUri.AbsolutePath);
+            Assert.Contains("grant_type=client_credentials", handler.LastRequestContent);
+
+            var authorization = handler.LastRequest.Headers.Authorization;
+            Assert.Equal("Basic", authorization.Scheme);
+            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(authorization.Parameter));
+            Assert.Equal($"{TestClientFactory.Key}:{TestClientFactory.Secret}", decoded);
+        }
+
+        [Fact]
+        public async Task Token_WithoutSecret_Throws()
+        {
+            var handler = FakeHttpMessageHandler.Json("{}");
+            var client = TestClientFactory.Create(handler, withSecret: false);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => client.Tokens.CreateAsync());
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Adds Claude Code project integration, a comprehensive offline test suite with coverage tooling, a serialization regression guard, and a small `.editorconfig` naming rule. No changes to the shipping library code — this is tooling, tests, and config.

## What changed

### Claude Code integration (`11dc936`)
- `CLAUDE.md` with build/test commands, the strict-build constraints, and an architecture overview.
- `.claude/skills/`: `fetch-transloadit-docs`, `add-robot`, `add-credentials`, `add-service-endpoint`, `release-pack`.
- `.claude/agents/`: `csharp-build-reviewer` (checks changed C# against the strict build) and `docs-coverage-auditor` (reports robots/params documented upstream but missing in code).

### Offline tests, coverage tooling, serialization snapshot (`a32636b`)
- **Test infrastructure**: `FakeHttpMessageHandler` + `TestClientFactory` exercise the full request/response pipeline with **no live API credentials** (via the injectable `HttpClient`/`ApiBase`).
- **Unit tests** for signatures, SmartCDN URL signing, the JSON converters, `AnyOf<>`, base params/responses, the client pipeline (signed/unsigned, multipart vs query, token Basic-auth), every service endpoint, and the assembly tracker.
- **Reflection-driven smoke tests** over every robot and credentials model.
- **Serialization snapshot**: a characterization test that pins the JSON contract shape (resolved key + type + converter) of every `Models` class to a committed golden file, so a future edit that changes serialization fails the test. Regenerate intentionally with `UPDATE_SNAPSHOTS=1`.
- **Coverage tooling**: `coverlet.runsettings`, a pinned ReportGenerator local tool (`.config/dotnet-tools.json`), and a `coverage` skill that emits an AI-readable summary. `.gitignore` now ignores `TestResults/`.
- Result: **200 offline tests, 99.3% line / 100% method coverage** of `src/Transloadit`.

### editorconfig (`68846fc`)
- New naming rule: **static fields are PascalCase** (`required_modifiers = static`, so it's more specific than the instance-field `_camelCase` rule).

## Notes for reviewers
- All new tests run without credentials; the pre-existing live `Tests/Api/*` suite is unchanged and still needs `appsettings.Tests.json`.
- The serialization snapshot deliberately preserves `RobotBilling`'s camelCase keys (the billing endpoint returns camelCase) — the `[JsonProperty]` attribute is treated as the source of truth, not a naming convention.
- The ~5 remaining uncovered lines are unreachable `default:` guard arms in exhaustive enum switches (`AnyOf`, `SignatureUtilities`); they were intentionally left rather than tested via reflection of impossible states.

## Heads-up (not addressed here)
- `tests/Transloadit.Tests/appsettings.Tests.json` contains real-looking committed auth key/secret — worth rotating/purging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
