### PR TITLE
Add /http/request robot; harden docs tooling against stale LLM index

### DIFF
--- a/.claude/agents/docs-coverage-auditor.md
+++ b/.claude/agents/docs-coverage-auditor.md
@@ -7,7 +7,12 @@ description: Audits drift between the Transloadit docs and the Transloadit Sharp
 
 You compare what Transloadit documents against what this library implements, and report the gaps. You are read-only: produce a report, suggest fixes (e.g. "run the add-robot skill for /x/y"), but do not edit files.
 
-The authoritative docs source is Transloadit's machine-readable dump (see the `fetch-transloadit-docs` skill for the format): `https://transloadit.com/llms.txt` is the robot index, `https://transloadit.com/llms-full.txt` holds each robot's Zod schema. Download both with `curl` to your scratch dir once; `WebFetch` truncates the large file.
+Transloadit's machine-readable dump (see the `fetch-transloadit-docs` skill for the format) is the starting point: `https://transloadit.com/llms.txt` is the robot index, `https://transloadit.com/llms-full.txt` holds each robot's Zod schema. Download both with `curl` to your scratch dir once; `WebFetch` truncates the large file.
+
+**⚠️ The LLM index can be stale.** It has listed robots (with full schemas) whose docs page 404s / is unpublished (e.g. `/document/extract`, `/mega/import`) or is removed (e.g. `/edgly/deliver`). Treat the index as a candidate list only — it is **not** authoritative for whether a robot is current. Any robot you would report as "missing → add it" must first be validated as a **published docs page**, using reliable server-side signals — **not `WebFetch`**, which fabricates content for 404 SPA pages:
+- **sitemap:** `curl -sSL https://transloadit.com/sitemap.xml | grep -oE 'docs/robots/[a-z-]+' | sort -u` — the slug must appear.
+- **status/title:** `curl` the docs URL and check for `200` + `<title>/x/y | Transloadit</title>` (a missing page returns `404` + `<title>404 - Not Found …</title>`).
+Do not recommend implementing a robot whose page is 404 / absent from the sitemap / removed.
 
 ## 1. Robot coverage (primary)
 
@@ -29,7 +34,7 @@ comm -23 "$SCRATCH/docs_robots.txt" "$SCRATCH/code_robots.txt"   # documented bu
 comm -13 "$SCRATCH/docs_robots.txt" "$SCRATCH/code_robots.txt"   # implemented but NOT in docs → deprecated/renamed/typo?
 ```
 
-For each **missing** robot, pull its one-line description from `llms.txt` and infer the target category folder.
+For each **missing** robot, pull its one-line description from `llms.txt`, infer the target category folder, and **validate it is a published docs page** using the sitemap + `curl` status/`<title>` checks above (not `WebFetch`). Exclude 404/unpublished/removed ones from the "add these" list and instead call them out as index-only/stale.
 For each **stale-in-code** robot, check whether it was renamed upstream (search `llms-full.txt` for a similar path) versus genuinely removed.
 
 ## 2. Per-robot parameter drift (deep mode — when asked, or for robots the user names)
@@ -50,7 +55,8 @@ For a robot present in both sides:
 Return a concise, ranked report — not file dumps:
 
 - **Summary:** `N documented robots, M implemented, K missing, S stale`.
-- **Missing in code** (highest priority): bulleted `/x/y — <one-line docs description> — suggested folder <Category>`. Note these can be added with the `add-robot` skill.
+- **Missing in code** (highest priority) — only robots whose live docs page confirms they are current: bulleted `/x/y — <one-line docs description> — suggested folder <Category> — stage <alpha/beta/ga>`. Note these can be added with the `add-robot` skill.
+- **Index-only / removed** — robots the LLM index lists but the live docs mark as removed/deprecated (or that 404 as genuinely gone): list separately and recommend **not** adding them.
 - **In code, not in docs:** list with a short hypothesis (renamed? deprecated? typo in the `Robot` string?).
 - **Parameter drift** (only if run): per robot, the missing/extra keys.
 - If everything matches, say so plainly.

--- a/.claude/skills/add-robot/SKILL.md
+++ b/.claude/skills/add-robot/SKILL.md
@@ -12,7 +12,7 @@ Robots are strongly-typed step models under `src/Transloadit/Models/Robots/<Cate
 1. **Resolve slug + category.** From the robot path `/x/y`, derive the docs slug (`/image/resize` → `image-resize`) and map the Transloadit doc category to an existing folder:
    `AI`, `AudioEncoding`, `Code`, `Documents`, `FileCompressing`, `FileExporting`, `FileFiltering`, `FileImporting`, `ImageManipulation`, `MediaCataloging`, `SmartCdn`, `VideoEncoding`.
 
-2. **Fetch the parameter spec** using the `fetch-transloadit-docs` skill.
+2. **Fetch the parameter spec** using the `fetch-transloadit-docs` skill. That skill also covers the mandatory **existence/status check**: the `llms.txt`/`llms-full.txt` index can be stale (it lists robots that 404 or are removed), so before writing any code confirm the robot has a **published docs page** — check the `sitemap.xml` and the `curl` HTTP status + server-rendered `<title>` of `https://transloadit.com/docs/robots/<slug>/` (do **not** use `WebFetch` — it fabricates content for 404 pages). If the page is 404 / not in the sitemap / marked removed, **do not implement it** — report that to the user instead.
 
 3. **Open a sibling** in the same category folder and mirror it — it is the source of truth for idioms. Pick the base class from `src/Transloadit/Models/Robots/RobotBase.cs`:
    - `RobotBase` — default.
@@ -51,3 +51,5 @@ Robots are strongly-typed step models under `src/Transloadit/Models/Robots/<Cate
    dotnet test tests/Transloadit.Tests/Transloadit.Tests.csproj -f net8.0 --filter "FullyQualifiedName~NewRobotsTests"
    ```
    Optionally hand the diff to the `csharp-build-reviewer` agent.
+
+10. **Re-confirm existence (post-check).** As a final step, re-check each robot you added against the `sitemap.xml` and the `curl` HTTP status/`<title>` of its docs page — the LLM index that seeded the work may have been out of date. Drop any robot whose page 404s, is absent from the sitemap, or is marked removed.

--- a/.claude/skills/fetch-transloadit-docs/SKILL.md
+++ b/.claude/skills/fetch-transloadit-docs/SKILL.md
@@ -5,7 +5,27 @@ description: Fetch the authoritative parameter spec for a Transloadit Robot or A
 
 # Fetch Transloadit docs
 
-Pull the authoritative parameter list for a Robot or API endpoint so a C# model maps exactly. The reliable source is Transloadit's machine-readable **`llms-full.txt`**, which contains a **Zod schema** for every robot — exact keys, types, defaults, and descriptions. The rendered HTML pages and per-robot `.md` pages are JS stubs that omit parameters, so do **not** rely on `WebFetch` against them.
+Pull the authoritative parameter list for a Robot or API endpoint so a C# model maps exactly. The reliable source **for parameters** is Transloadit's machine-readable **`llms-full.txt`**, which contains a **Zod schema** for every robot — exact keys, types, defaults, and descriptions. The rendered HTML pages and per-robot `.md` pages are JS stubs that omit parameters, so do **not** rely on `WebFetch` against them for the parameter list.
+
+## ⚠️ The LLM index can be stale — verify against the live docs page
+
+`llms-full.txt` / `llms.txt` are **not authoritative for whether a robot exists or is current**. They lag behind the live docs and have listed robots (with full schemas) that either 404 (no published docs page — e.g. `/document/extract`, `/mega/import`, `/image/enhance`) or are marked removed (e.g. `/edgly/deliver`). So **before implementing** a robot and **after** (as a final check), verify it exists as a published docs page.
+
+**Use reliable, server-side signals — NOT `WebFetch`.** `WebFetch` renders/summarizes these JS SPA pages with a small model and has been observed to **fabricate plausible content (fake headings, fake "beta/ga" stages) for pages that actually 404** — do not trust it for existence/status. Instead:
+
+1. **Sitemap** (authoritative list of published pages):
+   ```sh
+   curl -sSL https://transloadit.com/sitemap.xml | grep -oE 'docs/robots/[a-z-]+' | sort -u
+   ```
+   If the robot's slug is **not** in the sitemap, its docs page is not published — treat it as not available.
+2. **HTTP status + server-rendered `<title>`** (the title is rendered server-side even on the SPA):
+   ```sh
+   curl -sS -o /dev/null -w '%{http_code}\n' -L "https://transloadit.com/docs/robots/<slug>/"
+   curl -sSL "https://transloadit.com/docs/robots/<slug>/" | grep -oiE '<title>[^<]*</title>'
+   ```
+   A real page returns `200` with `<title>/x/y | Transloadit</title>`; a missing one returns `404` with `<title>404 - Not Found | Transloadit</title>`.
+
+If the robot is **404 / not in the sitemap / removed → do not implement it** (and if it already exists in the repo, flag it for removal). Trust the sitemap + HTTP/title over the LLM index whenever they disagree.
 
 ## Slug mapping
 

--- a/src/Transloadit/Models/Robots/Code/HttpRequestRobot.cs
+++ b/src/Transloadit/Models/Robots/Code/HttpRequestRobot.cs
@@ -1,0 +1,96 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Transloadit.Models.Robots.Code
+{
+    /// <summary>
+    /// Represents <a href="https://transloadit.com/docs/robots/http-request/">/http/request</a> Robot.
+    /// <para>Calls an HTTP endpoint during the Assembly and expects optional JSON describing zero or more input files
+    /// or result-file URLs to emit from this Step. Your endpoint must return a 2xx response.</para>
+    /// </summary>
+    public class HttpRequestRobot : RobotBase
+    {
+        /// <summary>
+        /// Specifies which Step(s) to use as input.
+        /// </summary>
+        [JsonProperty("use")]
+        public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
+
+        /// <summary>
+        /// The HTTP or HTTPS endpoint to call.
+        /// </summary>
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        /// <summary>
+        /// HTTP method to use for the request. One of <c>DELETE</c>, <c>GET</c>, <c>PATCH</c>, <c>POST</c>, or <c>PUT</c>.
+        /// <para>Default: <c>POST</c>.</para>
+        /// </summary>
+        [JsonProperty("method")]
+        public string Method { get; set; }
+
+        /// <summary>
+        /// Controls what is sent to your endpoint.
+        /// <list type="bullet">
+        /// <item><c>none</c> sends no request body.</item>
+        /// <item><c>metadata</c> sends a JSON body with Assembly metadata, fields, the previous Step, and file metadata.</item>
+        /// <item><c>file</c> sends multipart form data with a <c>payload</c> JSON field and the first input file as a <c>file</c> part.</item>
+        /// <item><c>files</c> sends multipart form data with a <c>payload</c> JSON field and all input files as repeated <c>files[]</c> parts.</item>
+        /// </list>
+        /// <para>Default: <c>none</c>.</para>
+        /// </summary>
+        [JsonProperty("payload")]
+        public string Payload { get; set; }
+
+        /// <summary>
+        /// Custom request headers. Can be specified as an object map of header names to values, or an array of strings
+        /// in the format <c>"Header-Name: value"</c>.
+        /// </summary>
+        [JsonProperty("headers")]
+        public AnyOf<Dictionary<string, string>, List<string>> Headers { get; set; }
+
+        /// <summary>
+        /// Maximum number of seconds to wait for the HTTP request. The effective timeout is the lower of this value and
+        /// Transloadit's server-side cap.
+        /// <para>Default: <c>60</c>.</para>
+        /// </summary>
+        [JsonProperty("timeout")]
+        public int? Timeout { get; set; }
+
+        /// <summary>
+        /// Maximum accepted response size in bytes. The response should normally be a small JSON document.
+        /// <para>Default: <c>1048576</c>.</para>
+        /// </summary>
+        [JsonProperty("max_response_size")]
+        public int? MaxResponseSize { get; set; }
+
+        /// <summary>
+        /// Maximum number of files that the endpoint may return.
+        /// <para>Default: <c>10</c>.</para>
+        /// </summary>
+        [JsonProperty("max_result_files")]
+        public int? MaxResultFiles { get; set; }
+
+        /// <summary>
+        /// Maximum allowed size in bytes for each result file returned by URL.
+        /// <para>Default: <c>104857600</c>.</para>
+        /// </summary>
+        [JsonProperty("max_result_file_size")]
+        public long? MaxResultFileSize { get; set; }
+
+        /// <summary>
+        /// Maximum number of seconds to spend downloading each result file returned by URL.
+        /// <para>Default: <c>120</c>.</para>
+        /// </summary>
+        [JsonProperty("result_download_timeout")]
+        public int? ResultDownloadTimeout { get; set; }
+
+        /// <summary>
+        /// Initializes <a href="https://transloadit.com/docs/robots/http-request/">/http/request</a> Robot.
+        /// </summary>
+        public HttpRequestRobot()
+        {
+            Robot = "/http/request";
+        }
+    }
+}

--- a/tests/Transloadit.Tests/Snapshots/models.serialization.snapshot.json
+++ b/tests/Transloadit.Tests/Snapshots/models.serialization.snapshot.json
@@ -2956,6 +2956,65 @@
     ]
   },
   {
+    "type": "Transloadit.Models.Robots.Code.HttpRequestRobot",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "headers",
+        "type": "AnyOf<Dictionary<String, String>, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "max_response_size",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "max_result_file_size",
+        "type": "Nullable<Int64>"
+      },
+      {
+        "name": "max_result_files",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "method",
+        "type": "String"
+      },
+      {
+        "name": "payload",
+        "type": "String"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result_download_timeout",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      },
+      {
+        "name": "timeout",
+        "type": "Nullable<Int32>"
+      },
+      {
+        "name": "url",
+        "type": "String"
+      },
+      {
+        "name": "use",
+        "type": "AnyOf<String, List<String>, AdvancedUse>",
+        "converter": "AnyOfConverter"
+      }
+    ]
+  },
+  {
     "type": "Transloadit.Models.Robots.Code.ScriptRunRobot",
     "properties": [
       {

--- a/tests/Transloadit.Tests/Tests/NewRobotsTests.cs
+++ b/tests/Transloadit.Tests/Tests/NewRobotsTests.cs
@@ -2,6 +2,7 @@ using Transloadit.Constants;
 using Transloadit.Models.Robots;
 using Transloadit.Models.Robots.AI;
 using Transloadit.Models.Robots.AudioEncoding;
+using Transloadit.Models.Robots.Code;
 using Transloadit.Models.Robots.Documents;
 using Transloadit.Models.Robots.FileExporting;
 using Transloadit.Models.Robots.FileImporting;
@@ -29,6 +30,8 @@ namespace Transloadit.Tests.Tests
             Assert.Equal("/video/artwork", new VideoArtworkRobot().Robot);
             Assert.Equal("/video/ondemand", new VideoOndemandRobot().Robot);
             Assert.Equal("/video/split", new VideoSplitRobot().Robot);
+
+            Assert.Equal("/http/request", new HttpRequestRobot().Robot);
         }
 
         [Fact]


### PR DESCRIPTION
## Overview

Implements the one genuinely-missing, published robot the library lacked, and hardens the docs tooling so a stale LLM index can't cause bogus robots to be added again.

## What changed

### `/http/request` robot
- New `HttpRequestRobot` (`src/Transloadit/Models/Robots/Code/`) with full XML docs, snake_case `[JsonProperty]` mapping, `AnyOf<>` for the multi-shape `headers` field, and `long?` for `max_result_file_size` (its max exceeds int32).
- `NewRobotsTests` assertion added; Models serialization snapshot regenerated.

### Tooling hardened against a stale index
`fetch-transloadit-docs`, `add-robot`, and `docs-coverage-auditor` now require verifying a robot has a **published docs page** before implementing it.

## Why this is small

The docs-coverage audit flagged 7 robots as "documented but missing." On verification against Transloadit's **sitemap** and each page's HTTP status + server-rendered `<title>`, only `/http/request` is actually published:

| Robot | Status |
|---|---|
| `/http/request` | 200, in sitemap — **implemented** |
| `/edgly/deliver` | removed ("no longer supported") — skipped |
| `/document/extract` | 404 / not in sitemap — skipped |
| `/image/copyrightdetect` | 404 / not in sitemap — skipped |
| `/image/enhance` | 404 / not in sitemap — skipped |
| `/mega/import` | 404 / not in sitemap — skipped |
| `/mega/store` | 404 / not in sitemap — skipped |

Those 6 appear in `llms.txt` / `llms-full.txt` with full Zod schemas but have no published docs page. Their XML doc-links would be dead, so they were not shipped. They can be added later if/when Transloadit publishes their docs.

**Note:** `WebFetch` was found to *fabricate* plausible "available (beta/ga)" content for pages that actually 404, so the tooling now explicitly forbids using it for existence/status checks and mandates the sitemap + `curl` status/`<title>` signals instead.

## Verification
- Clean Release build on **net8.0** and **net48** (0 warnings, `TreatWarningsAsErrors`).
- **201 offline tests pass**; reflection smoke test now enumerates 89 robots and the serialization snapshot matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
