### PR TITLE
Model universal robot params on base classes (interpolate, queue, output_meta, ignore_errors)

### DIFF
--- a/docs/robot-parameter-coverage.md
+++ b/docs/robot-parameter-coverage.md
@@ -1,0 +1,59 @@
+# Robot parameter coverage (follow-up backlog)
+
+This library models a curated subset of each Robot's parameters. The universal generic params
+(`result`, `force_accept`, `output_meta`, `interpolate`, `queue`, and `ignore_errors` for non-import
+Robots; `credentials`, `path`, `force_name`, `import_on_errors` for imports) live on the base classes in
+`src/Transloadit/Models/Robots/RobotBase.cs`. (`return_file_stubs` is documented by only 9 of 18 import
+Robots, so it is modelled per-robot rather than on the base.)
+
+The following **141 robot-specific parameters across 42 Robots** are documented by Transloadit but
+not yet modelled. They are the tracked backlog for follow-up work (add via the `add-robot` skill's
+per-parameter mapping). Source of truth is each Robot's docs page parameter table.
+
+| Robot | Missing documented params | File |
+|---|---|---|
+| `/audio/waveform` | `amplitude_scale`, `axis_label_color`, `bar_gap`, `bar_style`, `bar_width`, `bits`, `border_color`, `color_map`, `colors`, `compression`, `end`, `ffmpeg`, `ffmpeg_stack`, `frequency_max`, `frequency_min`, `frequency_scale`, `gain`, `legend`, `no_axis_labels`, `orientation`, `pixels_per_second`, `split_channels`, `start`, `waveform_style`, `with_axis_labels`, `zoom` | `src/Transloadit/Models/Robots/AudioEncoding/AudioWaveformImageRobot.cs` |
+| `/video/encode` | `segment`, `segment_duration`, `segment_name`, `segment_prefix`, `segment_time_delta`, `watermark_duration`, `watermark_opacity`, `watermark_position`, `watermark_resize_strategy`, `watermark_size`, `watermark_start_time`, `watermark_url`, `watermark_x_offset`, `watermark_y_offset` | `src/Transloadit/Models/Robots/VideoEncoding/VideoEncodeRobot.cs` |
+| `/image/merge` | `cell_height`, `cell_width`, `columns`, `coverage`, `effect`, `height`, `rows`, `seed`, `shuffle`, `sort_by`, `width` | `src/Transloadit/Models/Robots/ImageManipulation/ImageMergeRobot.cs` |
+| `/video/subtitle` | `bold`, `height`, `italic`, `keep_subtitles`, `language`, `name`, `outline_width`, `width` | `src/Transloadit/Models/Robots/VideoEncoding/VideoSubtitleRobot.cs` |
+| `/image/resize` | `clut`, `contrast`, `monochrome`, `shave`, `watermark_opacity`, `watermark_repeat_x`, `watermark_repeat_y` | `src/Transloadit/Models/Robots/ImageManipulation/ImageResizeRobot.cs` |
+| `/video/adaptive` | `audio_group`, `ffmpeg`, `ffmpeg_stack`, `height`, `hls_playlist_name`, `preset`, `width` | `src/Transloadit/Models/Robots/VideoEncoding/VideoAdaptiveRobot.cs` |
+| `/video/concat` | `chapter_markers`, `height`, `sort_by`, `transition`, `transition_duration`, `width` | `src/Transloadit/Models/Robots/VideoEncoding/VideoConcatenateRobot.cs` |
+| `/video/merge` | `image_url`, `loop`, `sort_by`, `transition`, `transition_duration` | `src/Transloadit/Models/Robots/VideoEncoding/VideoMergeRobot.cs` |
+| `/image/bgremove` | `ignore_errors`, `model`, `provider`, `select` | `src/Transloadit/Models/Robots/ImageManipulation/ImageBackgroundRemove.cs` |
+| `/video/thumbs` | `ffmpeg`, `input_codec`, `smart`, `smart_max_candidates` | `src/Transloadit/Models/Robots/VideoEncoding/VideoThumbnailsRobot.cs` |
+| `/document/thumbs` | `page_range`, `stack`, `turbo` | `src/Transloadit/Models/Robots/Documents/DocumentThumbnailsRobot.cs` |
+| `/file/preview` | `artwork_center_color`, `artwork_outer_color`, `zoom` | `src/Transloadit/Models/Robots/MediaCataloging/FilePreviewRobot.cs` |
+| `/sftp/import` | `force_name`, `import_on_errors`, `recursive` | `src/Transloadit/Models/Robots/FileImporting/SftpImportRobot.cs` |
+| `/speech/transcribe` | `max_speakers`, `speaker_labels`, `target_language` | `src/Transloadit/Models/Robots/AI/SpeechTranscribeRobot.cs` |
+| `/audio/artwork` | `ffmpeg`, `preset` | `src/Transloadit/Models/Robots/AudioEncoding/AudioArtworkRobot.cs` |
+| `/audio/concat` | `crossfade`, `sort_by` | `src/Transloadit/Models/Robots/AudioEncoding/AudioConcatenateRobot.cs` |
+| `/dropbox/import` | `access_token`, `refresh_token` | `src/Transloadit/Models/Robots/FileImporting/DropboxImportRobot.cs` |
+| `/file/compress` | `archive_name`, `path` | `src/Transloadit/Models/Robots/FileCompressing/FileCompressRobot.cs` |
+| `/file/decompress` | `password`, `turbo` | `src/Transloadit/Models/Robots/FileCompressing/FileDecompressRobot.cs` |
+| `/file/hash` | `partial`, `partial_size` | `src/Transloadit/Models/Robots/MediaCataloging/FileHashRobot.cs` |
+| `/ftp/import` | `force_name`, `import_on_errors` | `src/Transloadit/Models/Robots/FileImporting/FtpImportRobot.cs` |
+| `/http/import` | `max_file_size`, `range` | `src/Transloadit/Models/Robots/FileImporting/HttpImportRobot.cs` |
+| `/image/generate` | `num_outputs`, `provider` | `src/Transloadit/Models/Robots/AI/ImageGenerateRobot.cs` |
+| `/azure/import` | `recursive` | `src/Transloadit/Models/Robots/FileImporting/AzureImportRobot.cs` |
+| `/azure/store` | `content_disposition` | `src/Transloadit/Models/Robots/FileExporting/AzureStoreRobot.cs` |
+| `/cloudflare/store` | `url_prefix` | `src/Transloadit/Models/Robots/FileExporting/CloudFlareStoreRobot.cs` |
+| `/document/merge` | `sort_by` | `src/Transloadit/Models/Robots/Documents/DocumentMergeRobot.cs` |
+| `/file/serve` | `cache_duration` | `src/Transloadit/Models/Robots/SmartCdn/FileServeRobot.cs` |
+| `/file/verify` | `repair_pdf` | `src/Transloadit/Models/Robots/FileFiltering/FileVerifyRobot.cs` |
+| `/html/convert` | `wait_until` | `src/Transloadit/Models/Robots/Documents/HtmlConvertRobot.cs` |
+| `/image/optimize` | `lossy` | `src/Transloadit/Models/Robots/ImageManipulation/ImageOptimizeRobot.cs` |
+| `/meta/write` | `ffmpeg` | `src/Transloadit/Models/Robots/MediaCataloging/MetadataWriteRobot.cs` |
+| `/s3/import` | `range` | `src/Transloadit/Models/Robots/FileImporting/S3ImportRobot.cs` |
+| `/s3/store` | `session_token` | `src/Transloadit/Models/Robots/FileExporting/S3StoreRobot.cs` |
+| `/swift/import` | `bucket_region` | `src/Transloadit/Models/Robots/FileImporting/SwiftImportRobot.cs` |
+| `/swift/store` | `bucket_region` | `src/Transloadit/Models/Robots/FileExporting/SwiftStoreRobot.cs` |
+| `/tigris/import` | `bucket_region` | `src/Transloadit/Models/Robots/FileImporting/TigrisImportRobot.cs` |
+| `/tigris/store` | `bucket_region` | `src/Transloadit/Models/Robots/FileExporting/TigrisStoreRobot.cs` |
+| `/tlcdn/deliver` | `enable_hipaa_compliance` | `src/Transloadit/Models/Robots/SmartCdn/TlcdnDeliverRobot.cs` |
+| `/vimeo/store` | `folder_uri` | `src/Transloadit/Models/Robots/FileExporting/VimeoStoreRobot.cs` |
+| `/wasabi/import` | `bucket_region` | `src/Transloadit/Models/Robots/FileImporting/WasabiImportRobot.cs` |
+| `/wasabi/store` | `bucket_region` | `src/Transloadit/Models/Robots/FileExporting/WasabiStoreRobot.cs` |
+
+> Generated from the rendered Transloadit docs parameter tables vs. the current models. Regenerate
+> when robots or docs change (see the `docs-coverage-auditor` agent).

--- a/src/Transloadit/Models/Robots/AI/AiChatRobot.cs
+++ b/src/Transloadit/Models/Robots/AI/AiChatRobot.cs
@@ -6,19 +6,13 @@ namespace Transloadit.Models.Robots.AI
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/ai-chat/">/ai/chat</a> Robot.
     /// </summary>
-    public class AiChatRobot : RobotBase
+    public class AiChatRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Optional expensive metadata extraction settings.
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// The model to use. Set to <c>auto</c> to let Transloadit choose.

--- a/src/Transloadit/Models/Robots/AI/DocumentOcrRobot.cs
+++ b/src/Transloadit/Models/Robots/AI/DocumentOcrRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.AI
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/document-ocr/">/document/ocr</a> Robot.
     /// </summary>
-    public class DocumentOcrRobot : RobotBase
+    public class DocumentOcrRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/AI/ImageDescribeRobot.cs
+++ b/src/Transloadit/Models/Robots/AI/ImageDescribeRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.AI
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/image-describe/">/image/describe</a> Robot.
     /// </summary>
-    public class ImageDescribeRobot : RobotBase
+    public class ImageDescribeRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/AI/ImageFaceDetectRobot.cs
+++ b/src/Transloadit/Models/Robots/AI/ImageFaceDetectRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.AI
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/image-facedetect/">/image/facedetect</a> Robot.
     /// </summary>
-    public class ImageFaceDetectRobot : RobotBase
+    public class ImageFaceDetectRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/AI/ImageGenerateRobot.cs
+++ b/src/Transloadit/Models/Robots/AI/ImageGenerateRobot.cs
@@ -6,22 +6,13 @@ namespace Transloadit.Models.Robots.AI
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/image-generate/">/image/generate</a> Robot.
     /// </summary>
-    public class ImageGenerateRobot : RobotBase
+    public class ImageGenerateRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// The AI model to use for image generation. Please see the 

--- a/src/Transloadit/Models/Robots/AI/ImageOcrRobot.cs
+++ b/src/Transloadit/Models/Robots/AI/ImageOcrRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.AI
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/image-ocr/">/image/ocr</a> Robot.
     /// </summary>
-    public class ImageOcrRobot : RobotBase
+    public class ImageOcrRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/AI/SpeechTranscribeRobot.cs
+++ b/src/Transloadit/Models/Robots/AI/SpeechTranscribeRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.AI
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/speech-transcribe/">/speech/transcribe</a> Robot.
     /// </summary>
-    public class SpeechTranscribeRobot : RobotBase
+    public class SpeechTranscribeRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/AI/TextSpeakRobot.cs
+++ b/src/Transloadit/Models/Robots/AI/TextSpeakRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.AI
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/text-speak/">/text/speak</a> Robot.
     /// </summary>
-    public class TextSpeakRobot : RobotBase
+    public class TextSpeakRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/AI/TextTranslateRobot.cs
+++ b/src/Transloadit/Models/Robots/AI/TextTranslateRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.AI
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/text-translate/">/text/translate</a> Robot.
     /// </summary>
-    public class TextTranslateRobot : RobotBase
+    public class TextTranslateRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/AI/VideoGenerateRobot.cs
+++ b/src/Transloadit/Models/Robots/AI/VideoGenerateRobot.cs
@@ -6,19 +6,13 @@ namespace Transloadit.Models.Robots.AI
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/video-generate/">/video/generate</a> Robot.
     /// </summary>
-    public class VideoGenerateRobot : RobotBase
+    public class VideoGenerateRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Optional expensive metadata extraction settings.
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// The model to use.

--- a/src/Transloadit/Models/Robots/AudioEncoding/AudioArtworkRobot.cs
+++ b/src/Transloadit/Models/Robots/AudioEncoding/AudioArtworkRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.AudioEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/audio-artwork/">/audio/artwork</a> Robot.
     /// </summary>
-    public class AudioArtworkRobot : RobotBase
+    public class AudioArtworkRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/AudioEncoding/AudioConcatenateRobot.cs
+++ b/src/Transloadit/Models/Robots/AudioEncoding/AudioConcatenateRobot.cs
@@ -6,22 +6,13 @@ namespace Transloadit.Models.Robots.AudioEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/audio-concat/">/audio/concat</a> Robot.
     /// </summary>
-    public class AudioConcatenateRobot : RobotBase
+    public class AudioConcatenateRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// Performs conversion using pre-configured settings. If you specify your own FFmpeg parameters using the Robot's ffmpeg parameter 

--- a/src/Transloadit/Models/Robots/AudioEncoding/AudioEncodeRobot.cs
+++ b/src/Transloadit/Models/Robots/AudioEncoding/AudioEncodeRobot.cs
@@ -6,22 +6,13 @@ namespace Transloadit.Models.Robots.AudioEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/audio-encode/">/audio/encode</a> Robot.
     /// </summary>
-    public class AudioEncodeRobot : RobotBase
+    public class AudioEncodeRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// Performs conversion using pre-configured settings. If you specify your own FFmpeg parameters using the Robot's ffmpeg parameter 

--- a/src/Transloadit/Models/Robots/AudioEncoding/AudioLoopRobot.cs
+++ b/src/Transloadit/Models/Robots/AudioEncoding/AudioLoopRobot.cs
@@ -6,22 +6,13 @@ namespace Transloadit.Models.Robots.AudioEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/audio-loop/">/audio/loop</a> Robot.
     /// </summary>
-    public class AudioLoopRobot : RobotBase
+    public class AudioLoopRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// Performs conversion using pre-configured settings. If you specify your own FFmpeg parameters using the Robot's ffmpeg parameter 

--- a/src/Transloadit/Models/Robots/AudioEncoding/AudioMergeRobot.cs
+++ b/src/Transloadit/Models/Robots/AudioEncoding/AudioMergeRobot.cs
@@ -6,22 +6,13 @@ namespace Transloadit.Models.Robots.AudioEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/audio-merge/">/audio/merge</a> Robot.
     /// </summary>
-    public class AudioMergeRobot : RobotBase
+    public class AudioMergeRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// Performs conversion using pre-configured settings. If you specify your own FFmpeg parameters using the Robot's ffmpeg parameter 

--- a/src/Transloadit/Models/Robots/AudioEncoding/AudioSplitRobot.cs
+++ b/src/Transloadit/Models/Robots/AudioEncoding/AudioSplitRobot.cs
@@ -6,19 +6,13 @@ namespace Transloadit.Models.Robots.AudioEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/audio-split/">/audio/split</a> Robot.
     /// </summary>
-    public class AudioSplitRobot : RobotBase
+    public class AudioSplitRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Optional expensive metadata extraction settings.
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// FFmpeg options merged over preset options.

--- a/src/Transloadit/Models/Robots/AudioEncoding/AudioWaveformImageRobot.cs
+++ b/src/Transloadit/Models/Robots/AudioEncoding/AudioWaveformImageRobot.cs
@@ -6,22 +6,13 @@ namespace Transloadit.Models.Robots.AudioEncoding
     /// <summary>
     /// Represents <c>"/audio/waveform</c> Robot.
     /// </summary>
-    public class AudioWaveformImageRobot : RobotBase
+    public class AudioWaveformImageRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// The format of the result file. Can be <c>image</c> or <c>json</c>. If <c>image</c> is supplied, a PNG image will be created, 

--- a/src/Transloadit/Models/Robots/Code/ScriptRunRobot.cs
+++ b/src/Transloadit/Models/Robots/Code/ScriptRunRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.Code
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/script-run/">/script/run</a> Robot.
     /// </summary>
-    public class ScriptRunRobot : RobotBase
+    public class ScriptRunRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/Documents/DocumentAutoRotateRobot.cs
+++ b/src/Transloadit/Models/Robots/Documents/DocumentAutoRotateRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.Documents
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/document-autorotate/">/document/autorotate</a> Robot.
     /// </summary>
-    public class DocumentAutoRotateRobot : RobotBase
+    public class DocumentAutoRotateRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/Documents/DocumentConvertRobot.cs
+++ b/src/Transloadit/Models/Robots/Documents/DocumentConvertRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.Documents
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/document-convert/">/document/convert</a> Robot.
     /// </summary>
-    public class DocumentConvertRobot : RobotBase
+    public class DocumentConvertRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/Documents/DocumentMergeRobot.cs
+++ b/src/Transloadit/Models/Robots/Documents/DocumentMergeRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.Documents
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/document-merge/">/document/merge</a> Robot.
     /// </summary>
-    public class DocumentMergeRobot : RobotBase
+    public class DocumentMergeRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/Documents/DocumentOptimizeRobot.cs
+++ b/src/Transloadit/Models/Robots/Documents/DocumentOptimizeRobot.cs
@@ -6,19 +6,13 @@ namespace Transloadit.Models.Robots.Documents
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/document-optimize/">/document/optimize</a> Robot.
     /// </summary>
-    public class DocumentOptimizeRobot : RobotBase
+    public class DocumentOptimizeRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Optional expensive metadata extraction settings.
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// Quality preset. One of <see cref="Constants.DocumentOptimizePresets"/>.

--- a/src/Transloadit/Models/Robots/Documents/DocumentSplitRobot.cs
+++ b/src/Transloadit/Models/Robots/Documents/DocumentSplitRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.Documents
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/document-split/">/document/split</a> Robot.
     /// </summary>
-    public class DocumentSplitRobot : RobotBase
+    public class DocumentSplitRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/Documents/DocumentThumbnailsRobot.cs
+++ b/src/Transloadit/Models/Robots/Documents/DocumentThumbnailsRobot.cs
@@ -6,22 +6,13 @@ namespace Transloadit.Models.Robots.Documents
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/document-thumbs/">/document/thumbs</a> Robot.
     /// </summary>
-    public class DocumentThumbnailsRobot : RobotBase
+    public class DocumentThumbnailsRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// The PDF page that you want to convert to an image. By default the value is <c>null</c> which means that all pages will be converted into images.

--- a/src/Transloadit/Models/Robots/Documents/FileReadRobot.cs
+++ b/src/Transloadit/Models/Robots/Documents/FileReadRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.Documents
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/file-read/">/file/read</a> Robot.
     /// </summary>
-    public class FileReadRobot : RobotBase
+    public class FileReadRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/Documents/HtmlConvertRobot.cs
+++ b/src/Transloadit/Models/Robots/Documents/HtmlConvertRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.Documents
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/html-convert/">/html/convert</a> Robot.
     /// </summary>
-    public class HtmlConvertRobot : RobotBase
+    public class HtmlConvertRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/FileCompressing/FileCompressRobot.cs
+++ b/src/Transloadit/Models/Robots/FileCompressing/FileCompressRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.FileCompressing
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/file-compress/">/file/compress</a> Robot.
     /// </summary>
-    public class FileCompressRobot : RobotBase
+    public class FileCompressRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/FileCompressing/FileDecompressRobot.cs
+++ b/src/Transloadit/Models/Robots/FileCompressing/FileDecompressRobot.cs
@@ -6,22 +6,13 @@ namespace Transloadit.Models.Robots.FileCompressing
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/file-decompress/">/file/decompress</a> Robot.
     /// </summary>
-    public class FileDecompressRobot : RobotBase
+    public class FileDecompressRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// "Ignore errors" mode. Possible array members are <c>meta</c> and <c>import</c>. 
-        /// You might see an error when trying to extract metadata from your imported files. This happens, for example, for files with a size of zero bytes. Including <c>"meta"</c> in the array will cause the Robot to not stop the import (and the entire Assembly) when that happens.
-        /// Including <c>"import"</c> in the array will ensure the Robot does not cease to function on any import errors either.
-        /// Setting this parameter to <c>true</c> will set it to <c>["meta", "import"]</c> internally.
-        /// </summary>
-        [JsonProperty("ignore_errors")]
-        public AnyOf<bool, List<string>> IgnoreErrors { get; set; }
 
         /// <summary>
         /// Initializes <a href="https://transloadit.com/docs/robots/file-decompress/">/file/decompress</a> Robot.

--- a/src/Transloadit/Models/Robots/FileExporting/TusStoreRobot.cs
+++ b/src/Transloadit/Models/Robots/FileExporting/TusStoreRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.FileExporting
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/tus-store/">/tus/store</a> Robot.
     /// </summary>
-    public class TusStoreRobot : RobotBase
+    public class TusStoreRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/FileExporting/VimeoStoreRobot.cs
+++ b/src/Transloadit/Models/Robots/FileExporting/VimeoStoreRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.FileExporting
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/vimeo-store/">/vimeo/store</a> Robot.
     /// </summary>
-    public class VimeoStoreRobot : RobotBase
+    public class VimeoStoreRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/FileExporting/YoutubeStoreRobot.cs
+++ b/src/Transloadit/Models/Robots/FileExporting/YoutubeStoreRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.FileExporting
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/youtube-store/">/youtube/store</a> Robot.
     /// </summary>
-    public class YoutubeStoreRobot : RobotBase
+    public class YoutubeStoreRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/FileFiltering/FileFilterRobot.cs
+++ b/src/Transloadit/Models/Robots/FileFiltering/FileFilterRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.FileFiltering
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/file-filter/">/file/filter</a> Robot.
     /// </summary>
-    public class FileFilterRobot : RobotBase
+    public class FileFilterRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/FileFiltering/FileVerifyRobot.cs
+++ b/src/Transloadit/Models/Robots/FileFiltering/FileVerifyRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.FileFiltering
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/file-verify/">/file/verify</a> Robot.
     /// </summary>
-    public class FileVerifyRobot : RobotBase
+    public class FileVerifyRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/FileFiltering/FileVirusScanRobot.cs
+++ b/src/Transloadit/Models/Robots/FileFiltering/FileVirusScanRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.FileFiltering
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/file-virusscan/">/file/virusscan</a> Robot.
     /// </summary>
-    public class FileVirusScanRobot : RobotBase
+    public class FileVirusScanRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/FileImporting/BoxImportRobot.cs
+++ b/src/Transloadit/Models/Robots/FileImporting/BoxImportRobot.cs
@@ -9,12 +9,6 @@ namespace Transloadit.Models.Robots.FileImporting
     public class BoxImportRobot : ImportRobotBase
     {
         /// <summary>
-        /// Custom name for imported files.
-        /// </summary>
-        [JsonProperty("force_name")]
-        public AnyOf<string, List<string>> ForceName { get; set; }
-
-        /// <summary>
         /// Initializes <a href="https://transloadit.com/docs/robots/box-import/">/box/import</a> Robot.
         /// </summary>
         public BoxImportRobot()

--- a/src/Transloadit/Models/Robots/FileImporting/CloudFlareImportRobot.cs
+++ b/src/Transloadit/Models/Robots/FileImporting/CloudFlareImportRobot.cs
@@ -32,6 +32,14 @@ namespace Transloadit.Models.Robots.FileImporting
         public string Secret { get; set; }
 
         /// <summary>
+        /// If set to <c>true</c>, the Robot will not import the actual files yet, but instead returns an empty file stub that includes a URL from where the file can be imported by subsequent Robots.
+        /// This should only be set if all subsequent Steps use Robots that support file stubs.
+        /// <para>Default: <c>false</c>.</para>
+        /// </summary>
+        [JsonProperty("return_file_stubs")]
+        public bool? ReturnFileStubs { get; set; }
+
+        /// <summary>
         /// Initializes <a href="https://transloadit.com/docs/robots/cloudflare-import/">/cloudflare/import</a> Robot.
         /// </summary>
         public CloudFlareImportRobot()

--- a/src/Transloadit/Models/Robots/FileImporting/DigitalOceanImportRobot.cs
+++ b/src/Transloadit/Models/Robots/FileImporting/DigitalOceanImportRobot.cs
@@ -32,6 +32,14 @@ namespace Transloadit.Models.Robots.FileImporting
         public string Secret { get; set; }
 
         /// <summary>
+        /// If set to <c>true</c>, the Robot will not import the actual files yet, but instead returns an empty file stub that includes a URL from where the file can be imported by subsequent Robots.
+        /// This should only be set if all subsequent Steps use Robots that support file stubs.
+        /// <para>Default: <c>false</c>.</para>
+        /// </summary>
+        [JsonProperty("return_file_stubs")]
+        public bool? ReturnFileStubs { get; set; }
+
+        /// <summary>
         /// Initializes <a href="https://transloadit.com/docs/robots/digitalocean-import/">/digitalocean/import</a> Robot.
         /// </summary>
         public DigitalOceanImportRobot()

--- a/src/Transloadit/Models/Robots/FileImporting/FtpImportRobot.cs
+++ b/src/Transloadit/Models/Robots/FileImporting/FtpImportRobot.cs
@@ -9,15 +9,6 @@ namespace Transloadit.Models.Robots.FileImporting
     public class FtpImportRobot : RobotBase
     {
         /// <summary>
-        /// "Ignore errors" mode. Possible array members are <c>meta</c> and <c>import</c>. 
-        /// You might see an error when trying to extract metadata from your imported files. This happens, for example, for files with a size of zero bytes. Including <c>"meta"</c> in the array will cause the Robot to not stop the import (and the entire Assembly) when that happens.
-        /// Including <c>"import"</c> in the array will ensure the Robot does not cease to function on any import errors either.
-        /// Setting this parameter to <c>true</c> will set it to <c>["meta", "import"]</c> internally.
-        /// </summary>
-        [JsonProperty("ignore_errors")]
-        public AnyOf<bool, List<string>> IgnoreErrors { get; set; }
-
-        /// <summary>
         /// Template credentials name.
         /// </summary>
         [JsonProperty("credentials")]

--- a/src/Transloadit/Models/Robots/FileImporting/HttpImportRobot.cs
+++ b/src/Transloadit/Models/Robots/FileImporting/HttpImportRobot.cs
@@ -9,15 +9,6 @@ namespace Transloadit.Models.Robots.FileImporting
     public class HttpImportRobot : RobotBase
     {
         /// <summary>
-        /// "Ignore errors" mode. Possible array members are <c>meta</c> and <c>import</c>. 
-        /// You might see an error when trying to extract metadata from your imported files. This happens, for example, for files with a size of zero bytes. Including <c>"meta"</c> in the array will cause the Robot to not stop the import (and the entire Assembly) when that happens.
-        /// Including <c>"import"</c> in the array will ensure the Robot does not cease to function on any import errors either.
-        /// Setting this parameter to <c>true</c> will set it to <c>["meta", "import"]</c> internally.
-        /// </summary>
-        [JsonProperty("ignore_errors")]
-        public AnyOf<bool, List<string>> IgnoreErrors { get; set; }
-
-        /// <summary>
         /// The URL from which the file to be imported can be retrieved. You can also specify an array of URLs or a string of <c>|</c> 
         /// delimited URLs to import several files at once. Please also check the <c>url_delimiter</c> parameter for that.
         /// </summary>
@@ -57,6 +48,14 @@ namespace Transloadit.Models.Robots.FileImporting
         /// </summary>
         [JsonProperty("fail_fast")]
         public bool? FailFast { get; set; }
+
+        /// <summary>
+        /// If set to <c>true</c>, the Robot will not import the actual files yet, but instead returns an empty file stub that includes a URL from where the file can be imported by subsequent Robots.
+        /// This should only be set if all subsequent Steps use Robots that support file stubs.
+        /// <para>Default: <c>false</c>.</para>
+        /// </summary>
+        [JsonProperty("return_file_stubs")]
+        public bool? ReturnFileStubs { get; set; }
 
         /// <summary>
         /// Initializes <a href="https://transloadit.com/docs/robots/http-import/">/http/import</a> Robot.

--- a/src/Transloadit/Models/Robots/FileImporting/MinioImportRobot.cs
+++ b/src/Transloadit/Models/Robots/FileImporting/MinioImportRobot.cs
@@ -32,6 +32,14 @@ namespace Transloadit.Models.Robots.FileImporting
         public string Host { get; set; }
 
         /// <summary>
+        /// If set to <c>true</c>, the Robot will not import the actual files yet, but instead returns an empty file stub that includes a URL from where the file can be imported by subsequent Robots.
+        /// This should only be set if all subsequent Steps use Robots that support file stubs.
+        /// <para>Default: <c>false</c>.</para>
+        /// </summary>
+        [JsonProperty("return_file_stubs")]
+        public bool? ReturnFileStubs { get; set; }
+
+        /// <summary>
         /// Initializes <a href="https://transloadit.com/docs/robots/minio-import/">/minio/import</a> Robot.
         /// </summary>
         public MinioImportRobot()

--- a/src/Transloadit/Models/Robots/FileImporting/S3ImportRobot.cs
+++ b/src/Transloadit/Models/Robots/FileImporting/S3ImportRobot.cs
@@ -32,6 +32,14 @@ namespace Transloadit.Models.Robots.FileImporting
         public string BucketRegion { get; set; }
 
         /// <summary>
+        /// If set to <c>true</c>, the Robot will not import the actual files yet, but instead returns an empty file stub that includes a URL from where the file can be imported by subsequent Robots.
+        /// This should only be set if all subsequent Steps use Robots that support file stubs.
+        /// <para>Default: <c>false</c>.</para>
+        /// </summary>
+        [JsonProperty("return_file_stubs")]
+        public bool? ReturnFileStubs { get; set; }
+
+        /// <summary>
         /// Initializes <a href="https://transloadit.com/docs/robots/s3-import/">/s3/import</a> Robot.
         /// </summary>
         public S3ImportRobot()

--- a/src/Transloadit/Models/Robots/FileImporting/SftpImportRobot.cs
+++ b/src/Transloadit/Models/Robots/FileImporting/SftpImportRobot.cs
@@ -9,15 +9,6 @@ namespace Transloadit.Models.Robots.FileImporting
     public class SftpImportRobot : RobotBase
     {
         /// <summary>
-        /// "Ignore errors" mode. Possible array members are <c>meta</c> and <c>import</c>. 
-        /// You might see an error when trying to extract metadata from your imported files. This happens, for example, for files with a size of zero bytes. Including <c>"meta"</c> in the array will cause the Robot to not stop the import (and the entire Assembly) when that happens.
-        /// Including <c>"import"</c> in the array will ensure the Robot does not cease to function on any import errors either.
-        /// Setting this parameter to <c>true</c> will set it to <c>["meta", "import"]</c> internally.
-        /// </summary>
-        [JsonProperty("ignore_errors")]
-        public AnyOf<bool, List<string>> IgnoreErrors { get; set; }
-
-        /// <summary>
         /// Template credentials name.
         /// </summary>
         [JsonProperty("credentials")]

--- a/src/Transloadit/Models/Robots/FileImporting/SupabaseImportRobot.cs
+++ b/src/Transloadit/Models/Robots/FileImporting/SupabaseImportRobot.cs
@@ -38,6 +38,14 @@ namespace Transloadit.Models.Robots.FileImporting
         public string Secret { get; set; }
 
         /// <summary>
+        /// If set to <c>true</c>, the Robot will not import the actual files yet, but instead returns an empty file stub that includes a URL from where the file can be imported by subsequent Robots.
+        /// This should only be set if all subsequent Steps use Robots that support file stubs.
+        /// <para>Default: <c>false</c>.</para>
+        /// </summary>
+        [JsonProperty("return_file_stubs")]
+        public bool? ReturnFileStubs { get; set; }
+
+        /// <summary>
         /// Initializes <a href="https://transloadit.com/docs/robots/supabase-import/">/supabase/import</a> Robot.
         /// </summary>
         public SupabaseImportRobot()

--- a/src/Transloadit/Models/Robots/FileImporting/SwiftImportRobot.cs
+++ b/src/Transloadit/Models/Robots/FileImporting/SwiftImportRobot.cs
@@ -32,6 +32,14 @@ namespace Transloadit.Models.Robots.FileImporting
         public string Secret { get; set; }
 
         /// <summary>
+        /// If set to <c>true</c>, the Robot will not import the actual files yet, but instead returns an empty file stub that includes a URL from where the file can be imported by subsequent Robots.
+        /// This should only be set if all subsequent Steps use Robots that support file stubs.
+        /// <para>Default: <c>false</c>.</para>
+        /// </summary>
+        [JsonProperty("return_file_stubs")]
+        public bool? ReturnFileStubs { get; set; }
+
+        /// <summary>
         /// Initializes <a href="https://transloadit.com/docs/robots/swift-import/">/swift/import</a> Robot.
         /// </summary>
         public SwiftImportRobot()

--- a/src/Transloadit/Models/Robots/FileImporting/TigrisImportRobot.cs
+++ b/src/Transloadit/Models/Robots/FileImporting/TigrisImportRobot.cs
@@ -8,15 +8,6 @@ namespace Transloadit.Models.Robots.FileImporting
     public class TigrisImportRobot : PaginatedImportRobotBase
     {
         /// <summary>
-        /// If set to <c>true</c>, the Robot will not yet import the actual files but instead return an empty file stub that includes a URL 
-        /// from where the file can be imported by subsequent Robots. This is useful for cases where subsequent Steps need more control over 
-        /// the import process, such as with 🤖/video/ondemand. This parameter should only be set if all subsequent Steps use Robots 
-        /// that support file stubs.
-        /// </summary>
-        [JsonProperty("return_file_stubs")]
-        public bool? ReturnFileStubs { get; set; }
-
-        /// <summary>
         /// The name of the bucket to which the file is exported.
         /// </summary>
         [JsonProperty("bucket")]
@@ -39,6 +30,14 @@ namespace Transloadit.Models.Robots.FileImporting
         /// </summary>
         [JsonProperty("secret")]
         public string Secret { get; set; }
+
+        /// <summary>
+        /// If set to <c>true</c>, the Robot will not import the actual files yet, but instead returns an empty file stub that includes a URL from where the file can be imported by subsequent Robots.
+        /// This should only be set if all subsequent Steps use Robots that support file stubs.
+        /// <para>Default: <c>false</c>.</para>
+        /// </summary>
+        [JsonProperty("return_file_stubs")]
+        public bool? ReturnFileStubs { get; set; }
 
         /// <summary>
         /// Initializes <a href="https://transloadit.com/docs/robots/tigris-import/">/tigris/import</a> Robot.

--- a/src/Transloadit/Models/Robots/FileImporting/VimeoImportRobot.cs
+++ b/src/Transloadit/Models/Robots/FileImporting/VimeoImportRobot.cs
@@ -9,12 +9,6 @@ namespace Transloadit.Models.Robots.FileImporting
     public class VimeoImportRobot : ImportRobotBase
     {
         /// <summary>
-        /// Custom name for imported files.
-        /// </summary>
-        [JsonProperty("force_name")]
-        public AnyOf<string, List<string>> ForceName { get; set; }
-
-        /// <summary>
         /// Page number for paginated imports.
         /// </summary>
         [JsonProperty("page_number")]

--- a/src/Transloadit/Models/Robots/FileImporting/WasabiImportRobot.cs
+++ b/src/Transloadit/Models/Robots/FileImporting/WasabiImportRobot.cs
@@ -26,6 +26,14 @@ namespace Transloadit.Models.Robots.FileImporting
         public string Password { get; set; }
 
         /// <summary>
+        /// If set to <c>true</c>, the Robot will not import the actual files yet, but instead returns an empty file stub that includes a URL from where the file can be imported by subsequent Robots.
+        /// This should only be set if all subsequent Steps use Robots that support file stubs.
+        /// <para>Default: <c>false</c>.</para>
+        /// </summary>
+        [JsonProperty("return_file_stubs")]
+        public bool? ReturnFileStubs { get; set; }
+
+        /// <summary>
         /// Initializes <a href="https://transloadit.com/docs/robots/wasabi-import/">/wasabi/import</a> Robot.
         /// </summary>
         public WasabiImportRobot()

--- a/src/Transloadit/Models/Robots/ImageManipulation/ImageBackgroundRemove.cs
+++ b/src/Transloadit/Models/Robots/ImageManipulation/ImageBackgroundRemove.cs
@@ -15,15 +15,6 @@ namespace Transloadit.Models.Robots.ImageManipulation
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
 
         /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
-
-        /// <summary>
         /// The output format for the modified image. Currently, only <c>png</c> is supported. 
         /// To change the image format, you can use <see cref="ImageResizeRobot"/>.
         /// <para>Default: <c>png</c>.</para>

--- a/src/Transloadit/Models/Robots/ImageManipulation/ImageMergeRobot.cs
+++ b/src/Transloadit/Models/Robots/ImageManipulation/ImageMergeRobot.cs
@@ -6,22 +6,13 @@ namespace Transloadit.Models.Robots.ImageManipulation
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/image-merge/">/image/merge</a> Robot.
     /// </summary>
-    public class ImageMergeRobot : RobotBase
+    public class ImageMergeRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// The output format for the modified image. The currently available formats are either <c>jpg</c> or <c>png</c>.

--- a/src/Transloadit/Models/Robots/ImageManipulation/ImageOptimizeRobot.cs
+++ b/src/Transloadit/Models/Robots/ImageManipulation/ImageOptimizeRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.ImageManipulation
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/image-optimize/">/image/optimize</a> Robot.
     /// </summary>
-    public class ImageOptimizeRobot : RobotBase
+    public class ImageOptimizeRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/ImageManipulation/ImageResizeRobot.cs
+++ b/src/Transloadit/Models/Robots/ImageManipulation/ImageResizeRobot.cs
@@ -6,22 +6,13 @@ namespace Transloadit.Models.Robots.ImageManipulation
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/image-resize/">/image/resize</a> Robot.
     /// </summary>
-    public class ImageResizeRobot : RobotBase
+    public class ImageResizeRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// The output format for the modified image. Some of the most important available formats are "jpg", "png", "gif", and "tiff". For 

--- a/src/Transloadit/Models/Robots/ImageManipulation/ImageUpscaleRobot.cs
+++ b/src/Transloadit/Models/Robots/ImageManipulation/ImageUpscaleRobot.cs
@@ -6,19 +6,13 @@ namespace Transloadit.Models.Robots.ImageManipulation
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/image-upscale/">/image/upscale</a> Robot.
     /// </summary>
-    public class ImageUpscaleRobot : RobotBase
+    public class ImageUpscaleRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Optional expensive metadata extraction settings.
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// AI model used for upscaling. One of <see cref="Constants.ImageUpscaleModels"/>.

--- a/src/Transloadit/Models/Robots/MediaCataloging/FileHashRobot.cs
+++ b/src/Transloadit/Models/Robots/MediaCataloging/FileHashRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.MediaCataloging
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/file-hash/">/file/hash</a> Robot.
     /// </summary>
-    public class FileHashRobot : RobotBase
+    public class FileHashRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/MediaCataloging/FilePreviewRobot.cs
+++ b/src/Transloadit/Models/Robots/MediaCataloging/FilePreviewRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.MediaCataloging
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/file-preview/">/file/preview</a> Robot.
     /// </summary>
-    public class FilePreviewRobot : RobotBase
+    public class FilePreviewRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/MediaCataloging/MetadataWriteRobot.cs
+++ b/src/Transloadit/Models/Robots/MediaCataloging/MetadataWriteRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.MediaCataloging
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/meta-write/">/meta/write</a> Robot.
     /// </summary>
-    public class MetadataWriteRobot : RobotBase
+    public class MetadataWriteRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/RobotBase.cs
+++ b/src/Transloadit/Models/Robots/RobotBase.cs
@@ -27,6 +27,39 @@ namespace Transloadit.Models.Robots
         /// </summary>
         [JsonProperty("force_accept")]
         public bool? ForceAccept { get; set; }
+
+        /// <summary>
+        /// Optional expensive metadata extraction settings.
+        /// </summary>
+        [JsonProperty("output_meta")]
+        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
+
+        /// <summary>
+        /// Controls whether Assembly Variables are interpolated for individual instruction fields.
+        /// Set this to <c>false</c> to treat every instruction field as literal text, or set individual field paths (such as <c>path</c>, or a dotted path like <c>ffmpeg.vf</c> for nested objects) to <c>false</c> to treat only those fields as literal text.
+        /// </summary>
+        [JsonProperty("interpolate")]
+        public AnyOf<bool, Dictionary<string, object>> Interpolate { get; set; }
+
+        /// <summary>
+        /// Setting the queue to <c>batch</c> manually downgrades the priority of jobs for this Step, to avoid consuming Priority job slots for jobs that don't need zero queue waiting times.
+        /// </summary>
+        [JsonProperty("queue")]
+        public string Queue { get; set; }
+    }
+
+    /// <summary>
+    /// Represents base class for non-import Robots, which support the <c>ignore_errors</c> parameter.
+    /// </summary>
+    public abstract class ProcessingRobotBase : RobotBase
+    {
+        /// <summary>
+        /// "Ignore errors" mode. Possible array members are <c>meta</c> and <c>convert</c>.
+        /// You might see an error when trying to extract metadata from your files. This happens, for example, for files with a size of zero bytes. Including <c>"meta"</c> in the array will cause the Robot to not stop (and the entire Assembly) when that happens.
+        /// Setting this parameter to <c>true</c> will ignore all errors.
+        /// </summary>
+        [JsonProperty("ignore_errors")]
+        public AnyOf<bool, List<string>> IgnoreErrors { get; set; }
     }
 
     /// <summary>
@@ -34,15 +67,6 @@ namespace Transloadit.Models.Robots
     /// </summary>
     public abstract class ImportRobotBase : RobotBase
     {
-        /// <summary>
-        /// "Ignore errors" mode. Possible array members are <c>meta</c> and <c>import</c>. 
-        /// You might see an error when trying to extract metadata from your imported files. This happens, for example, for files with a size of zero bytes. Including <c>"meta"</c> in the array will cause the Robot to not stop the import (and the entire Assembly) when that happens.
-        /// Including <c>"import"</c> in the array will ensure the Robot does not cease to function on any import errors either.
-        /// Setting this parameter to <c>true</c> will set it to <c>["meta", "import"]</c> internally.
-        /// </summary>
-        [JsonProperty("ignore_errors")]
-        public AnyOf<bool, List<string>> IgnoreErrors { get; set; }
-
         /// <summary>
         /// Template credentials name.
         /// </summary>
@@ -54,12 +78,25 @@ namespace Transloadit.Models.Robots
         /// </summary>
         [JsonProperty("path")]
         public AnyOf<string, List<string>> Path { get; set; }
+
+        /// <summary>
+        /// Custom name for the imported file(s). By default file names are derived from the source.
+        /// </summary>
+        [JsonProperty("force_name")]
+        public AnyOf<string, List<string>> ForceName { get; set; }
+
+        /// <summary>
+        /// Setting this to <c>["meta"]</c> will still import the file on metadata extraction errors.
+        /// This is similar to <c>ignore_errors</c>, which also ignores the error and makes sure the Robot doesn't stop, but unlike this parameter it does not import the file.
+        /// </summary>
+        [JsonProperty("import_on_errors")]
+        public List<string> ImportOnErrors { get; set; }
     }
 
     /// <summary>
     /// Represents base class for store Robots.
     /// </summary>
-    public abstract class StoreRobotBase : RobotBase
+    public abstract class StoreRobotBase : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/SmartCdn/FileServeRobot.cs
+++ b/src/Transloadit/Models/Robots/SmartCdn/FileServeRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.SmartCdn
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/file-serve/">/file/serve</a> Robot.
     /// </summary>
-    public class FileServeRobot : RobotBase
+    public class FileServeRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/SmartCdn/TlcdnDeliverRobot.cs
+++ b/src/Transloadit/Models/Robots/SmartCdn/TlcdnDeliverRobot.cs
@@ -6,19 +6,13 @@ namespace Transloadit.Models.Robots.SmartCdn
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/tlcdn-deliver/">/tlcdn/deliver</a> Robot.
     /// </summary>
-    public class TlcdnDeliverRobot : RobotBase
+    public class TlcdnDeliverRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Optional expensive metadata extraction settings.
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// Initializes <a href="https://transloadit.com/docs/robots/tlcdn-deliver/">/tlcdn/deliver</a> Robot.

--- a/src/Transloadit/Models/Robots/UploadHandleRobot.cs
+++ b/src/Transloadit/Models/Robots/UploadHandleRobot.cs
@@ -6,17 +6,8 @@ namespace Transloadit.Models.Robots
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/upload-handle/">/upload/handle</a> Robot.
     /// </summary>
-    public class UploadHandleRobot : RobotBase
+    public class UploadHandleRobot : ProcessingRobotBase
     {
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
-
         /// <summary>
         /// Initializes <a href="https://transloadit.com/docs/robots/upload-handle/">/upload/handle</a> Robot.
         /// </summary>

--- a/src/Transloadit/Models/Robots/VideoEncoding/VideoAdaptiveRobot.cs
+++ b/src/Transloadit/Models/Robots/VideoEncoding/VideoAdaptiveRobot.cs
@@ -6,7 +6,7 @@ namespace Transloadit.Models.Robots.VideoEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/video-adaptive/">/video/adaptive</a> Robot.
     /// </summary>
-    public class VideoAdaptiveRobot : RobotBase
+    public class VideoAdaptiveRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.

--- a/src/Transloadit/Models/Robots/VideoEncoding/VideoArtworkRobot.cs
+++ b/src/Transloadit/Models/Robots/VideoEncoding/VideoArtworkRobot.cs
@@ -6,19 +6,13 @@ namespace Transloadit.Models.Robots.VideoEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/video-artwork/">/video/artwork</a> Robot.
     /// </summary>
-    public class VideoArtworkRobot : RobotBase
+    public class VideoArtworkRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Optional expensive metadata extraction settings.
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// FFmpeg options merged over preset options.

--- a/src/Transloadit/Models/Robots/VideoEncoding/VideoConcatenateRobot.cs
+++ b/src/Transloadit/Models/Robots/VideoEncoding/VideoConcatenateRobot.cs
@@ -6,22 +6,13 @@ namespace Transloadit.Models.Robots.VideoEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/video-concat/">/video/concat</a> Robot.
     /// </summary>
-    public class VideoConcatenateRobot : RobotBase
+    public class VideoConcatenateRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// Performs conversion using pre-configured settings. If you specify your own FFmpeg parameters using the Robot's <c>ffmpeg</c> parameter 

--- a/src/Transloadit/Models/Robots/VideoEncoding/VideoEncodeRobot.cs
+++ b/src/Transloadit/Models/Robots/VideoEncoding/VideoEncodeRobot.cs
@@ -7,22 +7,13 @@ namespace Transloadit.Models.Robots.VideoEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/video-encode/">/video/encode</a> Robot.
     /// </summary>
-    public class VideoEncodeRobot : RobotBase
+    public class VideoEncodeRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// Converts a video according to pre-configured settings. If you specify your own FFmpeg parameters using the Robot's and/or do not 

--- a/src/Transloadit/Models/Robots/VideoEncoding/VideoMergeRobot.cs
+++ b/src/Transloadit/Models/Robots/VideoEncoding/VideoMergeRobot.cs
@@ -6,22 +6,13 @@ namespace Transloadit.Models.Robots.VideoEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/video-merge/">/video/merge</a> Robot.
     /// </summary>
-    public class VideoMergeRobot : RobotBase
+    public class VideoMergeRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// Generates the video according to pre-configured video presets. If you specify your own FFmpeg parameters using the Robot's <c>ffmpeg</c> 

--- a/src/Transloadit/Models/Robots/VideoEncoding/VideoOndemandRobot.cs
+++ b/src/Transloadit/Models/Robots/VideoEncoding/VideoOndemandRobot.cs
@@ -6,19 +6,13 @@ namespace Transloadit.Models.Robots.VideoEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/video-ondemand/">/video/ondemand</a> Robot.
     /// </summary>
-    public class VideoOndemandRobot : RobotBase
+    public class VideoOndemandRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Optional expensive metadata extraction settings.
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// Variant definitions indexed by output name.

--- a/src/Transloadit/Models/Robots/VideoEncoding/VideoSplitRobot.cs
+++ b/src/Transloadit/Models/Robots/VideoEncoding/VideoSplitRobot.cs
@@ -6,19 +6,13 @@ namespace Transloadit.Models.Robots.VideoEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/video-split/">/video/split</a> Robot.
     /// </summary>
-    public class VideoSplitRobot : RobotBase
+    public class VideoSplitRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Optional expensive metadata extraction settings.
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// FFmpeg options merged over preset options.

--- a/src/Transloadit/Models/Robots/VideoEncoding/VideoSubtitleRobot.cs
+++ b/src/Transloadit/Models/Robots/VideoEncoding/VideoSubtitleRobot.cs
@@ -6,22 +6,13 @@ namespace Transloadit.Models.Robots.VideoEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/video-subtitle/">/video/subtitle</a> Robot.
     /// </summary>
-    public class VideoSubtitleRobot : RobotBase
+    public class VideoSubtitleRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// Performs conversion using pre-configured settings. By default, no settings are applied and the original settings of the video are preserved.

--- a/src/Transloadit/Models/Robots/VideoEncoding/VideoThumbnailsRobot.cs
+++ b/src/Transloadit/Models/Robots/VideoEncoding/VideoThumbnailsRobot.cs
@@ -6,22 +6,13 @@ namespace Transloadit.Models.Robots.VideoEncoding
     /// <summary>
     /// Represents <a href="https://transloadit.com/docs/robots/video-thumbs/">/video/thumbs</a> Robot.
     /// </summary>
-    public class VideoThumbnailsRobot : RobotBase
+    public class VideoThumbnailsRobot : ProcessingRobotBase
     {
         /// <summary>
         /// Specifies which Step(s) to use as input.
         /// </summary>
         [JsonProperty("use")]
         public AnyOf<string, List<string>, AdvancedUse> Use { get; set; }
-
-        /// <summary>
-        /// Allows to specify a set of metadata that is more expensive on CPU power to calculate, 
-        /// and thus is disabled by default to keep your Assemblies processing fast.
-        /// This can be set to <c>false</c> to skip metadata extraction and speed up transcoding.
-        /// <para>Default: <c>{}</c>.</para>
-        /// </summary>
-        [JsonProperty("output_meta")]
-        public AnyOf<bool, OutputMeta> OutputMeta { get; set; }
 
         /// <summary>
         /// The number of thumbnails to be extracted. As some videos have incorrect durations, the actual number of thumbnails generated may be less 

--- a/tests/Transloadit.Tests/Snapshots/models.serialization.snapshot.json
+++ b/tests/Transloadit.Tests/Snapshots/models.serialization.snapshot.json
@@ -2074,6 +2074,16 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "mcp_servers",
         "type": "List<AiChatMcpServer>"
       },
@@ -2090,6 +2100,10 @@
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "reasoning_effort",
@@ -2138,7 +2152,26 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2176,7 +2209,26 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2219,11 +2271,30 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "min_confidence",
         "type": "Int32"
       },
       {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2261,6 +2332,16 @@
         "type": "Nullable<Int32>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "model",
         "type": "String"
       },
@@ -2271,6 +2352,10 @@
       },
       {
         "name": "prompt",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2316,7 +2401,26 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2350,7 +2454,26 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2380,11 +2503,30 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "prompt",
         "type": "String"
       },
       {
         "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2422,7 +2564,26 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2483,6 +2644,16 @@
         "converter": "AnyOfConverter"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "model",
         "type": "String"
       },
@@ -2511,6 +2682,10 @@
       },
       {
         "name": "provider",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2602,7 +2777,26 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "method",
+        "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2644,12 +2838,26 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2691,12 +2899,26 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2742,12 +2964,26 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2793,6 +3029,16 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "loop",
         "type": "Nullable<Boolean>"
       },
@@ -2803,6 +3049,10 @@
       },
       {
         "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2849,12 +3099,26 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -2924,6 +3188,16 @@
         "type": "Nullable<Int32>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "outer_color",
         "type": "String"
       },
@@ -2931,6 +3205,10 @@
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -2963,6 +3241,25 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
+      },
+      {
         "name": "result",
         "type": "Nullable<Boolean>"
       },
@@ -2987,6 +3284,25 @@
       {
         "name": "force_accept",
         "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -3015,12 +3331,27 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "markdown_format",
         "type": "String"
       },
       {
         "name": "markdown_theme",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "pdf_display_header_footer",
@@ -3047,6 +3378,10 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "queue",
+        "type": "String"
+      },
+      {
         "name": "result",
         "type": "Nullable<Boolean>"
       },
@@ -3069,11 +3404,30 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "input_passwords",
         "type": "List<String>"
       },
       {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "output_password",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -3107,8 +3461,18 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "image_dpi",
         "type": "AnyOf<Int32, String>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
         "converter": "AnyOfConverter"
       },
       {
@@ -3122,6 +3486,10 @@
       },
       {
         "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -3155,9 +3523,28 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "pages",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -3214,8 +3601,18 @@
         "type": "Nullable<Int32>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "imagemagick_stack",
         "type": "String"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "output_meta",
@@ -3229,6 +3626,10 @@
       {
         "name": "pdf_use_cropbox",
         "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "resize_strategy",
@@ -3263,6 +3664,25 @@
       {
         "name": "force_accept",
         "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -3307,8 +3727,27 @@
         "type": "Nullable<Int32>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "omit_background",
         "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -3357,7 +3796,26 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "password",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -3386,6 +3844,20 @@
         "name": "ignore_errors",
         "type": "AnyOf<Boolean, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -3438,6 +3910,16 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "key",
         "type": "String"
       },
@@ -3446,9 +3928,18 @@
         "type": "Dictionary<String, Object>"
       },
       {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -3501,9 +3992,28 @@
         "type": "Dictionary<String, String>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -3536,9 +4046,28 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -3579,13 +4108,32 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -3630,13 +4178,32 @@
         "type": "Dictionary<String, String>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "region",
@@ -3689,9 +4256,28 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -3724,6 +4310,21 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "password",
         "type": "String"
       },
@@ -3735,6 +4336,10 @@
       {
         "name": "port",
         "type": "Nullable<Int32>"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -3787,9 +4392,28 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -3842,13 +4466,32 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -3897,13 +4540,32 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -3960,6 +4622,16 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "key",
         "type": "String"
       },
@@ -3968,9 +4640,18 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -4023,6 +4704,21 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
@@ -4033,6 +4729,10 @@
       },
       {
         "name": "public_key",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -4090,13 +4790,32 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -4149,13 +4868,32 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -4208,13 +4946,32 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -4259,8 +5016,27 @@
         "type": "Dictionary<String, String>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "metadata",
         "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -4313,7 +5089,26 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "password",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -4363,6 +5158,21 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "password",
         "type": "String"
       },
@@ -4370,6 +5180,10 @@
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -4414,7 +5228,26 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "keywords",
+        "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -4470,6 +5303,25 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
+      },
+      {
         "name": "result",
         "type": "Nullable<Boolean>"
       },
@@ -4498,6 +5350,25 @@
       {
         "name": "force_accept",
         "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -4532,6 +5403,25 @@
       {
         "name": "force_accept",
         "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -4572,8 +5462,17 @@
         "type": "Nullable<Boolean>"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
         "converter": "AnyOfConverter"
       },
       {
@@ -4585,9 +5484,18 @@
         "type": "String"
       },
       {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -4627,14 +5535,32 @@
         "type": "Nullable<Boolean>"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "recursive",
@@ -4671,14 +5597,27 @@
         "converter": "AnyOfConverter"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -4710,17 +5649,31 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "host",
         "type": "String"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "page_number",
@@ -4732,11 +5685,19 @@
         "converter": "AnyOfConverter"
       },
       {
+        "name": "queue",
+        "type": "String"
+      },
+      {
         "name": "recursive",
         "type": "Nullable<Boolean>"
       },
       {
         "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "return_file_stubs",
         "type": "Nullable<Boolean>"
       },
       {
@@ -4765,13 +5726,27 @@
         "type": "Nullable<Boolean>"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "page_number",
@@ -4783,6 +5758,10 @@
         "converter": "AnyOfConverter"
       },
       {
+        "name": "queue",
+        "type": "String"
+      },
+      {
         "name": "recursive",
         "type": "Nullable<Boolean>"
       },
@@ -4792,6 +5771,10 @@
       },
       {
         "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "return_file_stubs",
         "type": "Nullable<Boolean>"
       },
       {
@@ -4820,14 +5803,32 @@
         "type": "Nullable<Boolean>"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -4855,8 +5856,13 @@
         "type": "String"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
@@ -4874,6 +5880,10 @@
       {
         "name": "port",
         "type": "Nullable<Int32>"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -4905,8 +5915,17 @@
         "type": "Nullable<Boolean>"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
         "converter": "AnyOfConverter"
       },
       {
@@ -4914,9 +5933,18 @@
         "type": "String"
       },
       {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "recursive",
@@ -4953,16 +5981,29 @@
         "type": "List<String>"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
-        "converter": "AnyOfConverter"
-      },
-      {
         "name": "import_on_errors",
         "type": "List<String>"
       },
       {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
+      },
+      {
         "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "return_file_stubs",
         "type": "Nullable<Boolean>"
       },
       {
@@ -5000,17 +6041,31 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "host",
         "type": "String"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "page_number",
@@ -5022,11 +6077,19 @@
         "converter": "AnyOfConverter"
       },
       {
+        "name": "queue",
+        "type": "String"
+      },
+      {
         "name": "recursive",
         "type": "Nullable<Boolean>"
       },
       {
         "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "return_file_stubs",
         "type": "Nullable<Boolean>"
       },
       {
@@ -5067,13 +6130,27 @@
         "type": "Nullable<Boolean>"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "page_number",
@@ -5083,6 +6160,10 @@
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "recursive",
@@ -5126,13 +6207,27 @@
         "type": "Nullable<Boolean>"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "page_number",
@@ -5144,11 +6239,19 @@
         "converter": "AnyOfConverter"
       },
       {
+        "name": "queue",
+        "type": "String"
+      },
+      {
         "name": "recursive",
         "type": "Nullable<Boolean>"
       },
       {
         "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "return_file_stubs",
         "type": "Nullable<Boolean>"
       },
       {
@@ -5181,13 +6284,18 @@
         "type": "String"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "path",
@@ -5196,6 +6304,10 @@
       {
         "name": "port",
         "type": "Nullable<Int32>"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -5235,17 +6347,31 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "host",
         "type": "String"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "page_number",
@@ -5257,11 +6383,19 @@
         "converter": "AnyOfConverter"
       },
       {
+        "name": "queue",
+        "type": "String"
+      },
+      {
         "name": "recursive",
         "type": "Nullable<Boolean>"
       },
       {
         "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "return_file_stubs",
         "type": "Nullable<Boolean>"
       },
       {
@@ -5294,17 +6428,31 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "host",
         "type": "String"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "page_number",
@@ -5316,11 +6464,19 @@
         "converter": "AnyOfConverter"
       },
       {
+        "name": "queue",
+        "type": "String"
+      },
+      {
         "name": "recursive",
         "type": "Nullable<Boolean>"
       },
       {
         "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "return_file_stubs",
         "type": "Nullable<Boolean>"
       },
       {
@@ -5353,17 +6509,31 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "host",
         "type": "String"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "key",
         "type": "String"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "page_number",
@@ -5373,6 +6543,10 @@
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "recursive",
@@ -5417,8 +6591,17 @@
         "converter": "AnyOfConverter"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
@@ -5429,6 +6612,10 @@
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "rendition",
@@ -5460,12 +6647,26 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "host",
         "type": "String"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
@@ -5482,11 +6683,19 @@
         "converter": "AnyOfConverter"
       },
       {
+        "name": "queue",
+        "type": "String"
+      },
+      {
         "name": "recursive",
         "type": "Nullable<Boolean>"
       },
       {
         "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "return_file_stubs",
         "type": "Nullable<Boolean>"
       },
       {
@@ -5557,9 +6766,18 @@
         "type": "String"
       },
       {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -5604,6 +6822,16 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
@@ -5611,6 +6839,10 @@
       {
         "name": "quality",
         "type": "Nullable<Int32>"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -5639,6 +6871,21 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "preserve_meta_data",
         "type": "Nullable<Boolean>"
       },
@@ -5649,6 +6896,10 @@
       {
         "name": "progressive",
         "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -5747,8 +6998,18 @@
         "type": "Nullable<Int32>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "imagemagick_stack",
         "type": "String"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "negate",
@@ -5770,6 +7031,10 @@
       {
         "name": "quality",
         "type": "Nullable<Int32>"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "resize_strategy",
@@ -5868,6 +7133,16 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "model",
         "type": "String"
       },
@@ -5875,6 +7150,10 @@
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -5960,14 +7239,32 @@
         "type": "Nullable<Boolean>"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -5989,6 +7286,25 @@
       {
         "name": "force_accept",
         "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -6061,6 +7377,16 @@
         "type": "String"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "optimize",
         "type": "Nullable<Boolean>"
       },
@@ -6071,6 +7397,15 @@
       {
         "name": "optimize_progressive",
         "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "resize_strategy",
@@ -6129,6 +7464,25 @@
       {
         "name": "force_accept",
         "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -6215,8 +7569,22 @@
         "type": "Nullable<Boolean>"
       },
       {
-        "name": "ignore_errors",
-        "type": "AnyOf<Boolean, List<String>>",
+        "name": "force_name",
+        "type": "AnyOf<String, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "import_on_errors",
+        "type": "List<String>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
@@ -6229,8 +7597,48 @@
         "converter": "AnyOfConverter"
       },
       {
+        "name": "queue",
+        "type": "String"
+      },
+      {
         "name": "recursive",
         "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "result",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "robot",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Robots.ProcessingRobotBase",
+    "properties": [
+      {
+        "name": "force_accept",
+        "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -6248,6 +7656,20 @@
       {
         "name": "force_accept",
         "type": "Nullable<Boolean>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -6269,6 +7691,25 @@
       {
         "name": "headers",
         "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -6293,9 +7734,23 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -6324,9 +7779,28 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "path",
         "type": "AnyOf<String, List<String>>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -6351,9 +7825,23 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -6377,7 +7865,26 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "output_meta",
+        "type": "AnyOf<Boolean, OutputMeta>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "playlist_name",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -6419,6 +7926,16 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "method",
         "type": "String"
       },
@@ -6429,6 +7946,10 @@
       },
       {
         "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -6466,12 +7987,26 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -6534,12 +8069,26 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -6614,8 +8163,18 @@
         "type": "Nullable<Int32>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "image_durations",
         "type": "List<Double>"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
       },
       {
         "name": "output_meta",
@@ -6624,6 +8183,10 @@
       },
       {
         "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -6678,9 +8241,23 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "result",
@@ -6759,12 +8336,26 @@
         "converter": "AnyOfConverter"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
       },
       {
         "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -6842,6 +8433,16 @@
         "type": "Nullable<Boolean>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
@@ -6852,6 +8453,10 @@
       },
       {
         "name": "preset",
+        "type": "String"
+      },
+      {
+        "name": "queue",
         "type": "String"
       },
       {
@@ -6901,6 +8506,16 @@
         "type": "Nullable<Int32>"
       },
       {
+        "name": "ignore_errors",
+        "type": "AnyOf<Boolean, List<String>>",
+        "converter": "AnyOfConverter"
+      },
+      {
+        "name": "interpolate",
+        "type": "AnyOf<Boolean, Dictionary<String, Object>>",
+        "converter": "AnyOfConverter"
+      },
+      {
         "name": "offsets",
         "type": "AnyOf<List<Int32>, List<String>>",
         "converter": "AnyOfConverter"
@@ -6909,6 +8524,10 @@
         "name": "output_meta",
         "type": "AnyOf<Boolean, OutputMeta>",
         "converter": "AnyOfConverter"
+      },
+      {
+        "name": "queue",
+        "type": "String"
       },
       {
         "name": "resize_strategy",

--- a/tests/Transloadit.Tests/Tests/Unit/BaseRobotParamsTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/BaseRobotParamsTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Transloadit.Models.Robots;
+using Transloadit.Models.Robots.FileImporting;
+using Transloadit.Models.Robots.ImageManipulation;
+using Transloadit.Serialization;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Unit
+{
+    // guards the base-class generic-param model:
+    //   RobotBase           -> result, force_accept, output_meta, interpolate, queue  (universal)
+    //   ProcessingRobotBase -> ignore_errors                                          (non-import only)
+    //   ImportRobotBase     -> force_name, import_on_errors, return_file_stubs; NO ignore_errors
+    public class BaseRobotParamsTests
+    {
+        [Fact]
+        public void ProcessingRobot_SerializesUniversalAndIgnoreErrors()
+        {
+            var robot = new ImageResizeRobot
+            {
+                OutputMeta = true,
+                Interpolate = false,
+                Queue = "batch",
+                IgnoreErrors = true,
+            };
+
+            var json = JObject.Parse(JsonConvert.SerializeObject(robot, TransloaditSerializerSettings.CreateDefault()));
+
+            Assert.Equal(true, (bool)json["output_meta"]);
+            Assert.Equal(false, (bool)json["interpolate"]);
+            Assert.Equal("batch", (string)json["queue"]);
+            Assert.Equal(true, (bool)json["ignore_errors"]);
+        }
+
+        [Fact]
+        public void ImportRobot_SerializesUniversalAndImportParams_ButNotIgnoreErrors()
+        {
+            var robot = new S3ImportRobot
+            {
+                OutputMeta = true,
+                Queue = "batch",
+                ForceName = "renamed.jpg",
+                ImportOnErrors = new List<string> { "meta" },
+                ReturnFileStubs = true,
+            };
+
+            var json = JObject.Parse(JsonConvert.SerializeObject(robot, TransloaditSerializerSettings.CreateDefault()));
+
+            Assert.Equal(true, (bool)json["output_meta"]);
+            Assert.Equal("batch", (string)json["queue"]);
+            Assert.Equal("renamed.jpg", (string)json["force_name"]);
+            Assert.Equal("meta", (string)json["import_on_errors"][0]);
+            Assert.Equal(true, (bool)json["return_file_stubs"]);
+            Assert.Null(json["ignore_errors"]);
+        }
+
+        [Fact]
+        public void RobotBase_UniversalParams_AreOnEveryRobot()
+        {
+            foreach (var type in ConcreteRobotTypes())
+            {
+                Assert.NotNull(type.GetProperty("OutputMeta"));
+                Assert.NotNull(type.GetProperty("Interpolate"));
+                Assert.NotNull(type.GetProperty("Queue"));
+            }
+        }
+
+        [Fact]
+        public void IgnoreErrors_IsOnNonImportRobots_NotImports()
+        {
+            foreach (var type in ConcreteRobotTypes())
+            {
+                var isImport = typeof(ImportRobotBase).IsAssignableFrom(type);
+                var hasIgnoreErrors = type.GetProperty("IgnoreErrors") != null;
+                if (isImport)
+                {
+                    Assert.False(hasIgnoreErrors, $"{type.Name} is an import robot and must not expose IgnoreErrors");
+                }
+            }
+        }
+
+        [Fact]
+        public void ImportRobots_ExposeUniversalImportParams()
+        {
+            // force_name and import_on_errors are documented on every import robot (18/18);
+            // return_file_stubs is only on a subset (9/18), so it is modelled per-robot, not on the base.
+            foreach (var type in ConcreteRobotTypes().Where(t => typeof(ImportRobotBase).IsAssignableFrom(t)))
+            {
+                Assert.NotNull(type.GetProperty("ForceName"));
+                Assert.NotNull(type.GetProperty("ImportOnErrors"));
+            }
+        }
+
+        private static IEnumerable<Type> ConcreteRobotTypes()
+        {
+            return typeof(TransloaditClient).Assembly
+                .GetTypes()
+                .Where(t => typeof(RobotBase).IsAssignableFrom(t) && !t.IsAbstract && t.GetConstructor(Type.EmptyTypes) != null);
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Audits every robot's **documented** parameter table (extracted from the rendered Transloadit docs pages) against the C# models, and moves the truly-universal generic params onto the base classes — so all ~89 robots gain the params they document, modelled once. Adds a backlog doc for the remaining robot-specific params.

## Verified universality (docs param tables, not the exhaustive Zod schema)

| param | coverage | placement |
|---|---|---|
| `output_meta`, `interpolate`, `queue` | 89/89 (incl. all imports) | **`RobotBase`** |
| `ignore_errors` | store 19/19 + processing 52/52, **0/18 imports** | **`ProcessingRobotBase`** (new) |
| `force_name`, `import_on_errors` | 18/18 imports | **`ImportRobotBase`** |
| `return_file_stubs` | 9/18 imports | **per-robot** on those 9 (not a base param) |

## Changes

- **`RobotBase`** += `output_meta`, `interpolate` (`AnyOf<bool, Dictionary<string,object>>`), `queue`; the 25 per-robot `output_meta` declarations are deduped.
- **New `ProcessingRobotBase : RobotBase`** owns `ignore_errors`. `StoreRobotBase` now derives it, and the ~54 processing robots are reparented to it. `ignore_errors` is **removed** from `ImportRobotBase` and the ftp/http/sftp import stragglers (imports document `import_on_errors`, not `ignore_errors`).
- **`ImportRobotBase`** += `force_name`, `import_on_errors`. `return_file_stubs` added locally to the 9 imports that document it.

Resulting hierarchy:
```
RobotBase                       result, force_accept, output_meta, interpolate, queue
├─ ImportRobotBase              credentials, path, force_name, import_on_errors   (no ignore_errors)
│  └─ PaginatedImportRobotBase  recursive, page_number, files_per_page
└─ ProcessingRobotBase          ignore_errors
   └─ StoreRobotBase            use, credentials, path
```

## Correctness

A reverse audit confirms **every base param is documented by every robot that inherits it** — no base-class leaks introduced. The sole exception is the pre-existing `result` on `/image/generate` and `/video/generate` (those two AI robots' docs tables omit it; `result` is otherwise universal and lives on the root `RobotBase`).

The remaining **141 robot-specific documented params across 42 robots** (e.g. `/audio/waveform` +26, `/video/encode` +14) are tracked in `docs/robot-parameter-coverage.md` as follow-up.

## Verification
- Clean Release build on **net8.0** and **net48** (0 warnings, `TreatWarningsAsErrors`).
- **205 offline tests pass**, including the new `BaseRobotParamsTests` (structural guards: imports have no `IgnoreErrors`; all robots expose the universal params; imports expose `ForceName`/`ImportOnErrors`).
- Serialization snapshot regenerated and reviewed (only the intended keys added/moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
