### PR TITLE
Add dev tooling: branch-purge script + bump-version/purge-branches skills

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: bump-version
+description: Bump the NuGet package version of the Transloadit Sharp library. Use when the user wants to increment/raise/set the version, bump patch/minor/major, or prepare for a release (version change only — not the full pack/deploy, which is the release-pack skill).
+---
+
+# Bump version
+
+The package version is the single `<Version>` element in `src/Transloadit/Transloadit.csproj` (SemVer `MAJOR.MINOR.PATCH`). The deploy workflow tags the commit `v<Version>`.
+
+## Steps
+
+1. **Read the current version:**
+   ```sh
+   grep -oE '<Version>[^<]+</Version>' src/Transloadit/Transloadit.csproj
+   ```
+
+2. **Decide the new version** from the user's request:
+   - `patch` (default for a bugfix): `0.9.4` → `0.9.5`
+   - `minor` (new backwards-compatible feature): `0.9.4` → `0.10.0`
+   - `major` (breaking change): `0.9.4` → `1.0.0`
+   - or an explicit version the user gives (e.g. "bump to 1.2.0").
+   If the user didn't say which part, ask, or infer from the change (new robots/params → minor; fixes → patch; breaking API → major).
+
+3. **Edit** the `<Version>` value in `src/Transloadit/Transloadit.csproj` (Edit tool — change only that element).
+
+4. **Verify** it still builds and the version reads back:
+   ```sh
+   dotnet msbuild src/Transloadit/Transloadit.csproj -getProperty:Version
+   ```
+
+## Notes
+
+- **Don't reuse an existing tag.** The deploy workflow only tags `v<Version>` if that tag doesn't already exist, so a stale/duplicate version would silently skip tagging. Check `git tag -l "v<new>"` if unsure.
+- Bump the version **before** cutting a release — the actual pack/publish is the **release-pack** skill.
+- Do **not** commit or push the bump unless the user asks; changing a released version is outward-facing.

--- a/.claude/skills/purge-merged-branches/SKILL.md
+++ b/.claude/skills/purge-merged-branches/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: purge-merged-branches
+description: Clean up local git branches whose remote branch was deleted (e.g. after their PR merged). Use when the user wants to remove stale/merged/gone branches, tidy up local branches, or prune after merging PRs.
+---
+
+# Purge merged/gone local branches
+
+After a PR merges and its remote branch is deleted, the local branch that tracked it becomes stale (its upstream shows `[gone]`). This removes those.
+
+## Steps
+
+1. Make sure the working tree is clean and switch to a keep-around branch (usually `master`) so you're not sitting on one about to be deleted:
+   ```sh
+   git checkout master && git pull --ff-only
+   ```
+
+2. Run the repo script (prunes remote-tracking refs, then force-deletes every local branch whose upstream is gone; never deletes the current branch):
+   ```sh
+   sh scripts/purge-merged-branches.sh            # delete
+   sh scripts/purge-merged-branches.sh --dry-run  # preview only
+   ```
+
+3. Confirm what's left with `git branch`.
+
+## Notes
+
+- "Gone" means the upstream was deleted on the remote — normally because the PR merged. Branches without an upstream (never pushed) are **not** touched, and neither are branches whose remote still exists (e.g. open PRs).
+- The script uses `git branch -D` (force) because squash/rebase merges leave the local tip not-an-ancestor of `master`; the `[gone]` upstream is the safe signal that the work already landed. If you want extra caution, run `--dry-run` first.
+- The equivalent one-liner, if you don't want the script:
+  ```sh
+  git fetch --prune && git for-each-ref --format '%(refname:short) %(upstream:track)' refs/heads \
+    | awk '$2=="[gone]"{print $1}' | xargs -r git branch -D
+  ```

--- a/scripts/purge-merged-branches.sh
+++ b/scripts/purge-merged-branches.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+#
+# Purge local branches whose upstream has been deleted on the remote.
+#
+# After a pull request is merged and its remote branch is deleted, the local
+# branch that tracked it shows as "[gone]". This script prunes stale remote
+# tracking refs, then force-deletes those gone local branches. The current
+# branch is never deleted.
+#
+# Usage:
+#   sh scripts/purge-merged-branches.sh          # delete gone branches
+#   sh scripts/purge-merged-branches.sh --dry-run  # list them without deleting
+#
+set -eu
+
+dry_run=0
+[ "${1:-}" = "--dry-run" ] && dry_run=1
+
+# prune remote-tracking refs that no longer exist on the remote
+git fetch --prune
+
+current=$(git rev-parse --abbrev-ref HEAD)
+
+# a branch is "gone" when its configured upstream no longer exists
+gone=$(git for-each-ref --format '%(refname:short) %(upstream:track)' refs/heads \
+  | awk '$2 == "[gone]" { print $1 }')
+
+if [ -z "$gone" ]; then
+  echo "No gone branches to purge."
+  exit 0
+fi
+
+for branch in $gone; do
+  if [ "$branch" = "$current" ]; then
+    echo "skip (current branch): $branch"
+    continue
+  fi
+  if [ "$dry_run" -eq 1 ]; then
+    echo "would delete: $branch"
+  else
+    git branch -D "$branch"
+  fi
+done


### PR DESCRIPTION
## Overview

Adds developer tooling: a script to purge stale local branches after their PRs merge, and two Claude Code skills. No library/runtime changes.

## What's included

- **`scripts/purge-merged-branches.sh`** — prunes remote-tracking refs (`git fetch --prune`), then force-deletes every local branch whose upstream is `[gone]` (its remote branch was deleted, normally because the PR merged). Never deletes the current branch. Supports `--dry-run` to preview.
- **`.claude/skills/purge-merged-branches`** — wraps the script; triggers on "remove stale/merged/gone branches", "tidy up local branches", "prune after merging PRs".
- **`.claude/skills/bump-version`** — focused SemVer bump of `<Version>` in `src/Transloadit/Transloadit.csproj` (patch/minor/major, avoids reusing an existing `v<Version>` tag, no commit unless asked). Complements the existing `release-pack` skill, which does the full pack/deploy.

## Safety

The purge only removes branches whose upstream is gone — never-pushed branches and branches with a live remote (open PRs) are left untouched. `--dry-run` lists candidates without deleting.

## Verification
- `sh scripts/purge-merged-branches.sh --dry-run` runs cleanly and reports the gone branches (or none).
- Both `SKILL.md` files have valid frontmatter and appear in the skill listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
