### PR TITLE
Map notify_error, harden notification tests, clean up test warnings

### DIFF
--- a/src/Transloadit/Models/Assemblies/AssemblyResponse.cs
+++ b/src/Transloadit/Models/Assemblies/AssemblyResponse.cs
@@ -388,6 +388,12 @@ public class AssemblyResponse : ResponseBase
     public double? NotifyDuration { get; set; }
 
     /// <summary>
+    /// Error message from the notification attempt, if the notification failed; otherwise <c>null</c>.
+    /// </summary>
+    [TransloaditJsonName("notify_error")]
+    public string NotifyError { get; set; }
+
+    /// <summary>
     /// Date of the last completed job.
     /// </summary>
     [TransloaditJsonName("last_job_completed")]

--- a/tests/Transloadit.Tests/Infrastructure/FakeHttpMessageHandler.cs
+++ b/tests/Transloadit.Tests/Infrastructure/FakeHttpMessageHandler.cs
@@ -13,6 +13,7 @@ namespace Transloadit.Tests.Infrastructure;
 internal sealed class FakeHttpMessageHandler : HttpMessageHandler
 {
     private readonly Func<HttpRequestMessage, int, HttpResponseMessage> _responder;
+    private readonly object _sync = new object();
     private int _callCount;
 
     public FakeHttpMessageHandler(Func<HttpRequestMessage, int, HttpResponseMessage> responder)
@@ -44,20 +45,23 @@ internal sealed class FakeHttpMessageHandler : HttpMessageHandler
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var index = _callCount++;
-        LastRequest = request;
-        LastRequestUri = request.RequestUri;
-        LastMethod = request.Method;
-        RequestUris.Add(request.RequestUri);
+        // read the body before taking the lock — it is async and safe to run concurrently
+        var content = request.Content == null
+            ? null
+            : await request.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-        string content = null;
-        if (request.Content != null)
+        int index;
+        // serialize the shared-state capture so concurrent requests don't race on the counter/lists
+        lock (_sync)
         {
-            content = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+            index = _callCount++;
+            LastRequest = request;
+            LastRequestUri = request.RequestUri;
+            LastMethod = request.Method;
+            LastRequestContent = content;
+            RequestUris.Add(request.RequestUri);
+            RequestContents.Add(content);
         }
-
-        LastRequestContent = content;
-        RequestContents.Add(content);
 
         return _responder(request, index);
     }

--- a/tests/Transloadit.Tests/Snapshots/models.serialization.snapshot.json
+++ b/tests/Transloadit.Tests/Snapshots/models.serialization.snapshot.json
@@ -288,6 +288,10 @@
         "type": "Nullable<Double>"
       },
       {
+        "name": "notify_error",
+        "type": "String"
+      },
+      {
         "name": "notify_response_code",
         "type": "Nullable<Int32>"
       },

--- a/tests/Transloadit.Tests/Tests/Api/AssemblyLifecycleApiTests.cs
+++ b/tests/Transloadit.Tests/Tests/Api/AssemblyLifecycleApiTests.cs
@@ -149,9 +149,9 @@ public class AssemblyLifecycleApiTests : TestBase
         var unmapped = ResponseCoverage.UnmappedTopLevelKeys(handler.LastResponseBody, typeof(AssemblyResponse));
         _output.WriteLine("AssemblyResponse does not map: " + string.Join(", ", unmapped));
 
-        // regression guard: every key the API returns must be mapped, except a small reviewed allowlist.
-        // notify_error is notify-feature only (always null without a notify url) and intentionally not modeled.
-        var allowed = new HashSet<string> { "notify_error" };
+        // regression guard: every key the API returns must be mapped (the allowlist is now empty — a newly-returned
+        // API key that the model does not map fails the test)
+        var allowed = new HashSet<string>();
         var unexpected = unmapped.Where(k => !allowed.Contains(k)).ToList();
         Assert.True(
             unexpected.Count == 0,

--- a/tests/Transloadit.Tests/Tests/Api/AssemblyNotificationsApiTests.cs
+++ b/tests/Transloadit.Tests/Tests/Api/AssemblyNotificationsApiTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Transloadit.Constants;
 using Transloadit.Models.Assemblies;
+using Transloadit.Models.AssemblyNotifications;
 using Transloadit.Models.Robots;
 using Transloadit.Models.Templates;
 using Transloadit.Tests.Fixtures;
@@ -38,20 +39,39 @@ public class AssemblyNotificationsApiTests : TestBase
         Assert.Equal(ResponseCodes.AssemblyExecuting, createResponse.Base.Ok);
         Assert.Equal(Configuration.NotifyUrl, createResponse.NotifyUrl);
 
-        var assembly = await AssemblyTracker.WaitCompletionAsync(createResponse);
-        await WaitForNotificationAsync();
-        assembly = await TransloaditClient.Assemblies.GetAsync(createResponse.AssemblyId);
+        await AssemblyTracker.WaitCompletionAsync(createResponse);
+        var assembly = await WaitForNotificationAsync(createResponse.AssemblyId);
 
-        Assert.Equal(Configuration.NotifyUrl, assembly.NotifyUrl);
-        Assert.Equal(200, assembly.NotifyResponseCode);
-        Assert.True(assembly.NotifyDuration > 0d);
-        Assert.True(assembly.NotifyStart.HasValue);
-        Assert.NotNull(assembly.NotifyResponseData);
+        AssertNotificationSucceeded(assembly);
 
         var notificationReplayResponse = await TransloaditClient.AssemblyNotifications.ReplayAsync(assembly.AssemblyId);
 
         Assert.True(notificationReplayResponse.IsSuccessResponse());
         Assert.Equal(ResponseCodes.AssemblyNotificationReplayed, notificationReplayResponse.Base.Ok);
+    }
+
+    [Fact]
+    public async Task ReplayAssemblyNotificationWithOptions_Should_Succeed()
+    {
+        var assemblyRequest = new AssemblyRequest
+        {
+            Steps = new Dictionary<string, RobotBase>
+            {
+                ["import"] = TestDataFactory.GetDemoHttpImportRobot(),
+            },
+            NotifyUrl = Configuration.NotifyUrl,
+        };
+
+        var createResponse = await TransloaditClient.Assemblies.CreateAsync(assemblyRequest);
+        await AssemblyTracker.WaitCompletionAsync(createResponse);
+
+        // replay overriding the notify url and waiting for the replayed notification to finish
+        var replayResponse = await TransloaditClient.AssemblyNotifications.ReplayAsync(
+            createResponse.AssemblyId,
+            new ReplayNotificationRequest { NotifyUrl = Configuration.NotifyUrl, Wait = true });
+
+        Assert.True(replayResponse.IsSuccessResponse());
+        Assert.Equal(ResponseCodes.AssemblyNotificationReplayed, replayResponse.Base.Ok);
     }
 
     [Fact]
@@ -71,15 +91,12 @@ public class AssemblyNotificationsApiTests : TestBase
         Assert.Equal(ResponseCodes.AssemblyExecuting, createResponse.Base.Ok);
         Assert.Equal(Configuration.NotifyUrl, createResponse.NotifyUrl);
 
-        var assembly = await AssemblyTracker.WaitCompletionAsync(createResponse);
-        await WaitForNotificationAsync();
-        assembly = await TransloaditClient.Assemblies.GetAsync(createResponse.AssemblyId);
+        await AssemblyTracker.WaitCompletionAsync(createResponse);
+        var assembly = await WaitForNotificationAsync(createResponse.AssemblyId);
 
-        Assert.Equal(Configuration.NotifyUrl, assembly.NotifyUrl);
-        Assert.Equal(200, assembly.NotifyResponseCode);
-        Assert.True(assembly.NotifyDuration > 0d);
-        Assert.True(assembly.NotifyStart.HasValue);
-        Assert.NotNull(assembly.NotifyResponseData);
+        AssertNotificationSucceeded(assembly);
+        // a successful notification never carries an error
+        Assert.Null(assembly.NotifyError);
     }
 
     [Fact]
@@ -111,19 +128,39 @@ public class AssemblyNotificationsApiTests : TestBase
         Assert.Equal(ResponseCodes.AssemblyExecuting, createResponse.Base.Ok);
         Assert.Equal(Configuration.NotifyUrl, createResponse.NotifyUrl);
 
-        var assembly = await AssemblyTracker.WaitCompletionAsync(createResponse);
-        await WaitForNotificationAsync();
-        assembly = await TransloaditClient.Assemblies.GetAsync(createResponse.AssemblyId);
-        Assert.Equal(Configuration.NotifyUrl, assembly.NotifyUrl);
-        Assert.Equal(200, assembly.NotifyResponseCode);
-        Assert.True(assembly.NotifyDuration > 0d);
-        Assert.True(assembly.NotifyStart.HasValue);
-        Assert.NotNull(assembly.NotifyResponseData);
+        await AssemblyTracker.WaitCompletionAsync(createResponse);
+        var assembly = await WaitForNotificationAsync(createResponse.AssemblyId);
+        AssertNotificationSucceeded(assembly);
 
         var deleteTemplateResponse = await TransloaditClient.Templates.DeleteAsync(templateResponse.Id);
         Assert.True(deleteTemplateResponse.IsSuccessResponse());
         Assert.Equal(ResponseCodes.TemplateDeleted, deleteTemplateResponse.Base.Ok);
     }
 
-    private static async Task WaitForNotificationAsync(int delayMs = 3000) => await Task.Delay(delayMs);
+    private static void AssertNotificationSucceeded(AssemblyResponse assembly)
+    {
+        Assert.Equal(200, assembly.NotifyResponseCode);
+        Assert.True(assembly.NotifyDuration > 0d);
+        Assert.True(assembly.NotifyStart.HasValue);
+        Assert.NotNull(assembly.NotifyResponseData);
+    }
+
+    // poll the assembly until the notification has been delivered (notify_response_code populated) rather than
+    // waiting a fixed delay, which is flaky when the notification takes longer than expected
+    private async Task<AssemblyResponse> WaitForNotificationAsync(string assemblyId, int maxAttempts = 15, int delayMs = 2000)
+    {
+        AssemblyResponse assembly = null;
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            assembly = await TransloaditClient.Assemblies.GetAsync(assemblyId);
+            if (assembly.NotifyResponseCode.HasValue)
+            {
+                break;
+            }
+
+            await Task.Delay(delayMs);
+        }
+
+        return assembly;
+    }
 }

--- a/tests/Transloadit.Tests/Tests/Unit/BaseRobotParamsTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/BaseRobotParamsTests.cs
@@ -31,10 +31,10 @@ public class BaseRobotParamsTests
 
         var json = JObject.Parse(TestSerializer.Default.Serialize(robot));
 
-        Assert.Equal(true, (bool)json["output_meta"]);
-        Assert.Equal(false, (bool)json["interpolate"]);
+        Assert.True((bool)json["output_meta"]);
+        Assert.False((bool)json["interpolate"]);
         Assert.Equal("batch", (string)json["queue"]);
-        Assert.Equal(true, (bool)json["ignore_errors"]);
+        Assert.True((bool)json["ignore_errors"]);
     }
 
     [Fact]
@@ -51,11 +51,11 @@ public class BaseRobotParamsTests
 
         var json = JObject.Parse(TestSerializer.Default.Serialize(robot));
 
-        Assert.Equal(true, (bool)json["output_meta"]);
+        Assert.True((bool)json["output_meta"]);
         Assert.Equal("batch", (string)json["queue"]);
         Assert.Equal("renamed.jpg", (string)json["force_name"]);
         Assert.Equal("meta", (string)json["import_on_errors"][0]);
-        Assert.Equal(true, (bool)json["return_file_stubs"]);
+        Assert.True((bool)json["return_file_stubs"]);
         Assert.Null(json["ignore_errors"]);
     }
 

--- a/tests/Transloadit.Tests/Tests/Unit/ResponseDeserializationTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/ResponseDeserializationTests.cs
@@ -70,6 +70,21 @@ public class ResponseDeserializationTests
     }
 
     [Fact]
+    public void AssemblyResponse_MapsNotifyFields_IncludingNotifyError()
+    {
+        // notify_error is populated only when a notification fails; it must not be silently dropped
+        const string json =
+            "{\"ok\":\"ASSEMBLY_COMPLETED\",\"notify_url\":\"https://hook.test\"," +
+            "\"notify_response_code\":500,\"notify_error\":\"connection refused\"}";
+
+        var response = TestSerializer.Default.Deserialize<AssemblyResponse>(json);
+
+        Assert.Equal("https://hook.test", response.NotifyUrl);
+        Assert.Equal(500, response.NotifyResponseCode);
+        Assert.Equal("connection refused", response.NotifyError);
+    }
+
+    [Fact]
     public void BillingResponse_Deserializes_CamelCaseAndOverrideNames()
     {
         const string json =

--- a/tests/Transloadit.Tests/Tests/Unit/TransloaditClientPipelineTests.cs
+++ b/tests/Transloadit.Tests/Tests/Unit/TransloaditClientPipelineTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -143,15 +142,8 @@ public class TransloaditClientPipelineTests
         // one client shares a serializer and injects auth per request; concurrent calls must not race on that
         // shared state — every request must reach the wire exactly once with its own params and a signature
         const int count = 25;
-        var bodies = new ConcurrentBag<string>();
-        var handler = new FakeHttpMessageHandler((request, _) =>
-        {
-            bodies.Add(request.Content == null ? string.Empty : request.Content.ReadAsStringAsync().GetAwaiter().GetResult());
-            return new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(AssemblyJson, Encoding.UTF8, "application/json"),
-            };
-        });
+        // the handler reads each body asynchronously and captures it under a lock, so no blocking read is needed here
+        var handler = FakeHttpMessageHandler.Json(AssemblyJson);
         var client = TestClientFactory.Create(handler);
 
         var responses = await Task.WhenAll(
@@ -159,7 +151,7 @@ public class TransloaditClientPipelineTests
 
         Assert.All(responses, r => Assert.Equal("abc", r.AssemblyId));
 
-        var captured = bodies.ToList();
+        var captured = handler.RequestContents;
         Assert.Equal(count, captured.Count);
         Assert.All(captured, body => Assert.Contains("signature", body));
         // each distinct template id reached the wire exactly once (no lost/duplicated/cross-contaminated requests).


### PR DESCRIPTION
## What

Follows up the serializer/model work with notification coverage and a test-warning cleanup — all validated against the live API (NotifyUrl now configured).

### Test-analyzer warnings (`77c2923`)
- `BaseRobotParamsTests`: `Assert.True/False` instead of `Assert.Equal(true/false, …)` (**xUnit2004**).
- `FakeHttpMessageHandler` made thread-safe (lock around the shared counter/lists; body read stays async), and the concurrency test now reads the handler's captured bodies instead of a blocking `.GetAwaiter().GetResult()` in the responder (**xUnit1031**). Also fixes the previously racy `List.Add`.
- The test build is now free of xUnit analyzer warnings.

### notify_error + notification tests (`53c42c4`)
- **Map the previously-unmapped `AssemblyResponse.notify_error`** (`string`) so a failed notification's error is no longer silently dropped. The strict coverage guard's allowlist is now empty — `AssemblyResponse` maps every key the API returns.
- Pin `notify_error` deserialization with an offline test.
- Add a **replay-with-options** integration test exercising `ReplayNotificationRequest { NotifyUrl, Wait }`.
- Replace the flaky fixed `Task.Delay` in the notification tests with polling until `notify_response_code` populates.

## Live findings worth noting

- **No list-assembly-notifications endpoint exists.** `GET /assembly_notifications` returns `404 "unknown method / url"`, and the docs confirm only replay exists — so none was added (the earlier "feature gap" was a false positive from stale docs).
- **A failed notification's terminal fields populate very slowly** (`notify_start` sets immediately, but `notify_response_code`/`notify_error` stay null for 3+ minutes due to Transloadit's retry backoff), so `notify_error`'s shape is pinned by an offline test rather than a slow/flaky live one.

## Verification

- Offline suite: **242 net8.0 / 258 net461**.
- Live notification tests: **net8.0 6/6, net461 5/5**.
- Clean build across all 12 target frameworks; snapshot regenerated for the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)