### PR TITLE
Document provider-neutral attributes for custom models

### DIFF
--- a/.claude/skills/add-credentials/SKILL.md
+++ b/.claude/skills/add-credentials/SKILL.md
@@ -12,15 +12,17 @@ Credentials request models live in `src/Transloadit/Models/Credentials/`. `Crede
 1. **Fetch the content fields** for the service using the `fetch-transloadit-docs` skill (API credentials docs). Cross-check against an existing sibling such as `S3CredentialsRequest.cs` or `AzureCredentialsRequest.cs`.
 
 2. **Create** `src/Transloadit/Models/Credentials/<Svc>CredentialsRequest.cs` with two `public` classes in one file:
-   - `public class <Svc>CredentialsRequest : CredentialsRequestBase` (base in `CredentialsRequest.cs`; it provides `[JsonProperty("name")] Name`). The parameterless constructor sets the discriminator:
+   - `public class <Svc>CredentialsRequest : CredentialsRequestBase` (base in `CredentialsRequest.cs`; it provides `[TransloaditJsonName("name")] Name`). The parameterless constructor sets the discriminator:
      ```csharp
      public <Svc>CredentialsRequest()
      {
          Type = "<svc>";
      }
      ```
-     and exposes `[JsonProperty("content")] public <Svc>CredentialsContent Content { get; set; }`.
-   - `public class <Svc>CredentialsContent` holding the service fields, each with `[JsonProperty("snake_case_key")]`.
+     and exposes `[TransloaditJsonName("content")] public <Svc>CredentialsContent Content { get; set; }`.
+   - `public class <Svc>CredentialsContent` holding the service fields, each with `[TransloaditJsonName("snake_case_key")]` (omit the attribute when the key is exactly `snake_case(PropertyName)`).
+
+   Use the library's provider-neutral `Transloadit*` attributes (in `Transloadit.Serialization.Attributes`), **not** native `[JsonProperty]`/`[JsonPropertyName]`: the client serializes with System.Text.Json on `net462`+ and Newtonsoft on `net452`/`net461`, and a native attribute is honored on only one engine — so the JSON key would differ by target framework.
 
 3. **Conventions:** nullable value types use `?`; no `string?` (`Nullable` is disabled); full XML docs on every public type and member (build fails otherwise); comments lowercase, no trailing period.
 

--- a/.claude/skills/add-robot/SKILL.md
+++ b/.claude/skills/add-robot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-robot
-description: Add a new Transloadit Robot model class to the Transloadit Sharp library. Use when the user wants to implement/add a robot, gives a robot path like /image/resize or /ai/chat, or points at a robot docs URL. Handles picking the base class, the constructor Robot string, snake_case JsonProperty mapping, mandatory XML docs, and the NewRobotsTests assertion.
+description: Add a new Transloadit Robot model class to the Transloadit Sharp library. Use when the user wants to implement/add a robot, gives a robot path like /image/resize or /ai/chat, or points at a robot docs URL. Handles picking the base class, the constructor Robot string, snake_case TransloaditJsonName mapping, mandatory XML docs, and the NewRobotsTests assertion.
 ---
 
 # Add a Transloadit Robot
@@ -25,8 +25,9 @@ Robots are strongly-typed step models under `src/Transloadit/Models/Robots/<Cate
    - `public class <Name>Robot : <Base>`
    - parameterless constructor sets the path: `Robot = "/x/y";`
 
-5. **Map each parameter** to a `public` property:
-   - `[JsonProperty("snake_case_key")]` on every property.
+5. **Map each parameter** to a `public` property using the library's **provider-neutral attributes** (from `Transloadit.Serialization.Attributes`) — **never** a native serializer attribute like `[JsonProperty]` (Newtonsoft) or `[JsonPropertyName]` (System.Text.Json). The library serializes with System.Text.Json on `net462`+ and Newtonsoft on `net452`/`net461`; a native attribute is honored on only one engine and silently ignored (falling back to the snake_case default) on the other, so the JSON key would differ by target framework. Only the `Transloadit*` attributes are mapped by both adapters.
+   - `[TransloaditJsonName("snake_case_key")]` — **omit it when the key is exactly `snake_case(PropertyName)`** (both engines apply snake_case by default); add it only when the JSON key differs (e.g. `imagemagick_stack`, `rawGb`).
+   - `[TransloaditBooleanToInt]` for a `bool`/`bool?` the API expects as `1`/`0`; `[TransloaditDateFormat("…")]` for a fixed date format; `[TransloaditJsonIgnore]` to exclude — these have no portable native equivalent, so the neutral attribute is the only option.
    - nullable value types use `?` (`int?`, `bool?`, `double?`); reference types plain — do **not** write `string?` (`Nullable` is disabled).
    - multi-shape fields → `AnyOf<...>` (`src/Transloadit/Models/AnyOf.cs`).
    - enum-like string values → reuse or add a `src/Transloadit/Constants/` static class and reference it in the doc with `<see cref="Constants.X"/>`.

--- a/.claude/skills/add-service-endpoint/SKILL.md
+++ b/.claude/skills/add-service-endpoint/SKILL.md
@@ -14,7 +14,7 @@ Use `fetch-transloadit-docs` against the `/docs/api/` endpoint to get the path, 
 ## Mode A — new endpoint on an existing service
 
 1. Add request/response models as needed:
-   - request: `public class <X>Request : BaseParams` (or `PaginationParams` for lists), snake_case `[JsonProperty]` fields.
+   - request: `public class <X>Request : BaseParams` (or `PaginationParams` for lists), fields mapped with the provider-neutral `[TransloaditJsonName("snake_case_key")]` (omit it when the key is already `snake_case(PropertyName)`) — **not** native `[JsonProperty]`/`[JsonPropertyName]`, which each work on only one of the two serializer engines the library ships (Newtonsoft on `net452`/`net461`, System.Text.Json on `net462`+).
    - response: `public class <X>Response : ResponseBase`.
 2. Add the method to the service:
    ```csharp

--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,47 @@ var client = new TransloaditClient("<auth key>", "<auth secret>", new Transloadi
 > built-in serializers derive all of this from the models' provider-neutral attributes, so wrapping the default
 > is the recommended path.
 
+#### Attributes on your own models
+
+When you define your own model that flows through the client — a custom robot, credentials type, or request —
+annotate it with the library's **provider-neutral attributes**, not a specific serializer's native attributes:
+
+| Attribute | Purpose |
+| --- | --- |
+| `[TransloaditJsonName("snake_case_key")]` | JSON property name |
+| `[TransloaditJsonIgnore]` | exclude the property |
+| `[TransloaditBooleanToInt]` | serialize a `bool` as `1`/`0` |
+| `[TransloaditDateFormat("…")]` | format a date with a fixed .NET format string |
+
+They live in `Transloadit.Serialization.Attributes`. Both built-in adapters map them, so they behave identically on
+every target framework.
+
+**Do not use native serializer attributes** (`[JsonProperty]` from Newtonsoft, `[JsonPropertyName]` from
+System.Text.Json). The library uses **System.Text.Json on `net462`+ and Newtonsoft on `net452`/`net461`**, and each
+native attribute is invisible to the other engine — so a native attribute is honored on only some of the target
+frameworks and silently falls back to the default snake_case name on the rest, producing a different JSON key
+depending on where your code runs. A custom `ITransloaditSerializer` would ignore them entirely.
+
+```csharp
+using Transloadit.Models.Robots;
+using Transloadit.Serialization.Attributes;
+
+public class MyRobot : RobotBase
+{
+    public MyRobot() => Robot = "/my/robot";
+
+    // no attribute needed: the C# name already snake_cases to "resize_strategy" on both engines
+    public string ResizeStrategy { get; set; }
+
+    // attribute needed only when the JSON key differs from snake_case(PropertyName)
+    [TransloaditJsonName("imagemagick_stack")]
+    public string ImageMagickStack { get; set; }
+
+    [TransloaditBooleanToInt]
+    public bool? Turbo { get; set; }
+}
+```
+
 ### Create an Assembly
 
 Using a template


### PR DESCRIPTION
## What

Documents that custom models (robots, credentials, request types) must use the library's **provider-neutral `Transloadit*` attributes**, and fixes stale `[JsonProperty]` guidance left over from the Newtonsoft → System.Text.Json migration.

## Why

The client serializes with **System.Text.Json on `net462`+ and Newtonsoft on `net452`/`net461`**. A native attribute (`[JsonProperty]` / `[JsonPropertyName]`) is honored by only one engine and silently ignored by the other — falling back to the default snake_case name — so a native attribute produces a **different JSON key depending on the target framework**. Only the `Transloadit*` attributes are mapped by both adapters.

## Changes (docs only)

- **readme**: new "Attributes on your own models" subsection — the attribute table (`TransloaditJsonName`/`TransloaditJsonIgnore`/`TransloaditBooleanToInt`/`TransloaditDateFormat`), the cross-framework rationale, and a `MyRobot` example. Notes that the name attribute can be omitted when the key is already `snake_case(PropertyName)`.
- **skills**: `add-robot`, `add-credentials`, and `add-service-endpoint` all instructed the now-wrong `[JsonProperty]`; updated to `TransloaditJsonName` with the same rationale. (The migration changed the models to neutral attributes but these skills weren't updated.)

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)