### PR TITLE
Enforce explicit [TransloaditJsonName] on every public model property

### DIFF
--- a/src/Transloadit/Models/Credentials/CredentialsRequest.cs
+++ b/src/Transloadit/Models/Credentials/CredentialsRequest.cs
@@ -17,6 +17,7 @@ public abstract class CredentialsRequestBase : BaseParams
     /// <summary>
     /// Template credentials type.
     /// </summary>
+    [TransloaditJsonName("type")]
     public string Type { get; protected set; }
 }
 

--- a/src/Transloadit/Models/Robots/RobotBase.cs
+++ b/src/Transloadit/Models/Robots/RobotBase.cs
@@ -11,6 +11,7 @@ public abstract class RobotBase
     /// <summary>
     /// Robot which should process the files. For example <c>/ftp/import</c>.
     /// </summary>
+    [TransloaditJsonName("robot")]
     public string Robot { get; protected set; }
 
     /// <summary>

--- a/tests/Transloadit.Tests/Tests/Models/ModelPropertyNamingTests.cs
+++ b/tests/Transloadit.Tests/Tests/Models/ModelPropertyNamingTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Transloadit.Models;
+using Transloadit.Serialization.Attributes;
+using Xunit;
+
+namespace Transloadit.Tests.Tests.Models;
+
+// every public model property must declare an explicit [TransloaditJsonName] (or be excluded with
+// [TransloaditJsonIgnore]). making every name explicit means the two serializer engines — System.Text.Json's
+// SnakeCaseLower policy and Newtonsoft's SnakeCaseNamingStrategy — can never diverge on a property name, and a
+// newly-added model property can't silently rely on the default naming.
+public class ModelPropertyNamingTests
+{
+    [Fact]
+    public void EveryPublicModelProperty_DeclaresJsonNameOrIsIgnored()
+    {
+        var violations = new List<string>();
+
+        foreach (var type in SerializableModelTypes())
+        {
+            var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            foreach (var property in properties)
+            {
+                if (property.GetCustomAttribute<TransloaditJsonIgnoreAttribute>() != null)
+                {
+                    continue;
+                }
+
+                if (property.GetCustomAttribute<TransloaditJsonNameAttribute>() == null)
+                {
+                    violations.Add($"{type.FullName}.{property.Name}");
+                }
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "these public model properties must be marked with [TransloaditJsonName] (or [TransloaditJsonIgnore]):" +
+            Environment.NewLine + string.Join(Environment.NewLine, violations));
+    }
+
+    private static IEnumerable<Type> SerializableModelTypes()
+    {
+        return typeof(TransloaditClient).Assembly
+            .GetTypes()
+            .Where(type => type.IsClass
+                && type.IsVisible
+                && !type.IsGenericTypeDefinition
+                && (type.Namespace == "Transloadit.Models" || (type.Namespace?.StartsWith("Transloadit.Models.", StringComparison.Ordinal) ?? false))
+                // AnyOf<> is serialized by a dedicated converter, not property-by-property
+                && !typeof(AnyOf).IsAssignableFrom(type)
+                // TransloaditResponse is the raw HTTP wrapper; it is attached via an ignored property and never serialized
+                && type != typeof(TransloaditResponse));
+    }
+}


### PR DESCRIPTION
## What

Adds a reflection test — `ModelPropertyNamingTests` — that asserts **every public model property declares an explicit `[TransloaditJsonName]`** (or is excluded with `[TransloaditJsonIgnore]`).

## Why

Making every JSON name explicit means no property relies on the default snake_case naming policy — which removes any chance the two serializer engines (**System.Text.Json's `SnakeCaseLower`** and **Newtonsoft's `SnakeCaseNamingStrategy`**) diverge on a name, and prevents a newly-added property from silently going unnamed.

## Findings

The test surfaced two properties that were relying on the snake_case default (the regex I'd have used by hand missed one of them):
- `RobotBase.Robot` → `"robot"`
- `CredentialsRequestBase.Type` → `"type"`

Both now carry the explicit attribute — **same wire names, no behavior change** (the snapshot test needed no regeneration).

The test excludes `AnyOf<>` (serialized by a dedicated converter, not property-by-property) and `TransloaditResponse` (the raw HTTP wrapper, attached via an ignored property and never serialized).

## Verification

- New test + snapshot test pass; snapshot unchanged.
- Clean build across all 12 target frameworks.
- Offline suite: **243 net8.0 / 259 net461**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)