### PR TITLE
Add missing credential types: Google, Box, Dropbox, Vimeo, YouTube

### DIFF
--- a/src/Transloadit/Models/Credentials/BoxCredentialsRequest.cs
+++ b/src/Transloadit/Models/Credentials/BoxCredentialsRequest.cs
@@ -1,0 +1,42 @@
+using Transloadit.Serialization.Attributes;
+
+namespace Transloadit.Models.Credentials;
+
+/// <summary>
+/// Represents Box credentials request. Box uses OAuth, so the token values are normally obtained through the OAuth
+/// flow when generating Template Credentials.
+/// </summary>
+public class BoxCredentialsRequest : CredentialsRequestBase
+{
+    /// <summary>
+    /// Initializes Box credentials request.
+    /// </summary>
+    public BoxCredentialsRequest()
+    {
+        Type = "box";
+    }
+
+    /// <summary>
+    /// Box credentials content.
+    /// </summary>
+    [TransloaditJsonName("content")]
+    public BoxCredentialsContent Content { get; set; }
+}
+
+/// <summary>
+/// Represents Box credentials.
+/// </summary>
+public class BoxCredentialsContent
+{
+    /// <summary>
+    /// Box OAuth access token.
+    /// </summary>
+    [TransloaditJsonName("access_token")]
+    public string AccessToken { get; set; }
+
+    /// <summary>
+    /// Box OAuth refresh token. Optional; used together with <see cref="AccessToken"/> for dynamic credentials.
+    /// </summary>
+    [TransloaditJsonName("refresh_token")]
+    public string RefreshToken { get; set; }
+}

--- a/src/Transloadit/Models/Credentials/DropboxCredentialsRequest.cs
+++ b/src/Transloadit/Models/Credentials/DropboxCredentialsRequest.cs
@@ -1,0 +1,54 @@
+using Transloadit.Serialization.Attributes;
+
+namespace Transloadit.Models.Credentials;
+
+/// <summary>
+/// Represents Dropbox credentials request. Dropbox uses OAuth, so the token values are normally obtained through the
+/// OAuth flow when generating Template Credentials.
+/// </summary>
+public class DropboxCredentialsRequest : CredentialsRequestBase
+{
+    /// <summary>
+    /// Initializes Dropbox credentials request.
+    /// </summary>
+    public DropboxCredentialsRequest()
+    {
+        Type = "dropbox";
+    }
+
+    /// <summary>
+    /// Dropbox credentials content.
+    /// </summary>
+    [TransloaditJsonName("content")]
+    public DropboxCredentialsContent Content { get; set; }
+}
+
+/// <summary>
+/// Represents Dropbox credentials.
+/// </summary>
+public class DropboxCredentialsContent
+{
+    /// <summary>
+    /// Dropbox app key.
+    /// </summary>
+    [TransloaditJsonName("app_key")]
+    public string AppKey { get; set; }
+
+    /// <summary>
+    /// Dropbox app secret.
+    /// </summary>
+    [TransloaditJsonName("app_secret")]
+    public string AppSecret { get; set; }
+
+    /// <summary>
+    /// Dropbox OAuth access token.
+    /// </summary>
+    [TransloaditJsonName("access_token")]
+    public string AccessToken { get; set; }
+
+    /// <summary>
+    /// Dropbox OAuth refresh token. Optional; used together with <see cref="AccessToken"/> for dynamic credentials.
+    /// </summary>
+    [TransloaditJsonName("refresh_token")]
+    public string RefreshToken { get; set; }
+}

--- a/src/Transloadit/Models/Credentials/GoogleCredentialsRequest.cs
+++ b/src/Transloadit/Models/Credentials/GoogleCredentialsRequest.cs
@@ -1,0 +1,47 @@
+using Transloadit.Serialization.Attributes;
+
+namespace Transloadit.Models.Credentials;
+
+/// <summary>
+/// Represents Google Cloud Storage credentials request.
+/// </summary>
+public class GoogleCredentialsRequest : CredentialsRequestBase
+{
+    /// <summary>
+    /// Initializes Google Cloud Storage credentials request.
+    /// </summary>
+    public GoogleCredentialsRequest()
+    {
+        Type = "google";
+    }
+
+    /// <summary>
+    /// Google Cloud Storage credentials content.
+    /// </summary>
+    [TransloaditJsonName("content")]
+    public GoogleCredentialsContent Content { get; set; }
+}
+
+/// <summary>
+/// Represents Google Cloud Storage credentials.
+/// </summary>
+public class GoogleCredentialsContent
+{
+    /// <summary>
+    /// Google Cloud project id.
+    /// </summary>
+    [TransloaditJsonName("project_id")]
+    public string ProjectId { get; set; }
+
+    /// <summary>
+    /// Contents of the service account JSON key file.
+    /// </summary>
+    [TransloaditJsonName("key_file_contents")]
+    public string KeyFileContents { get; set; }
+
+    /// <summary>
+    /// Google Cloud Storage bucket name.
+    /// </summary>
+    [TransloaditJsonName("bucket")]
+    public string Bucket { get; set; }
+}

--- a/src/Transloadit/Models/Credentials/VimeoCredentialsRequest.cs
+++ b/src/Transloadit/Models/Credentials/VimeoCredentialsRequest.cs
@@ -1,0 +1,42 @@
+using Transloadit.Serialization.Attributes;
+
+namespace Transloadit.Models.Credentials;
+
+/// <summary>
+/// Represents Vimeo credentials request. Vimeo uses OAuth, so the token values are normally obtained through the
+/// OAuth flow when generating Template Credentials.
+/// </summary>
+public class VimeoCredentialsRequest : CredentialsRequestBase
+{
+    /// <summary>
+    /// Initializes Vimeo credentials request.
+    /// </summary>
+    public VimeoCredentialsRequest()
+    {
+        Type = "vimeo";
+    }
+
+    /// <summary>
+    /// Vimeo credentials content.
+    /// </summary>
+    [TransloaditJsonName("content")]
+    public VimeoCredentialsContent Content { get; set; }
+}
+
+/// <summary>
+/// Represents Vimeo credentials.
+/// </summary>
+public class VimeoCredentialsContent
+{
+    /// <summary>
+    /// Vimeo OAuth access token.
+    /// </summary>
+    [TransloaditJsonName("access_token")]
+    public string AccessToken { get; set; }
+
+    /// <summary>
+    /// Vimeo OAuth refresh token. Optional; used together with <see cref="AccessToken"/> for dynamic credentials.
+    /// </summary>
+    [TransloaditJsonName("refresh_token")]
+    public string RefreshToken { get; set; }
+}

--- a/src/Transloadit/Models/Credentials/YoutubeCredentialsRequest.cs
+++ b/src/Transloadit/Models/Credentials/YoutubeCredentialsRequest.cs
@@ -1,0 +1,42 @@
+using Transloadit.Serialization.Attributes;
+
+namespace Transloadit.Models.Credentials;
+
+/// <summary>
+/// Represents YouTube credentials request. YouTube uses OAuth, so the token values are normally obtained through the
+/// OAuth flow when generating Template Credentials.
+/// </summary>
+public class YoutubeCredentialsRequest : CredentialsRequestBase
+{
+    /// <summary>
+    /// Initializes YouTube credentials request.
+    /// </summary>
+    public YoutubeCredentialsRequest()
+    {
+        Type = "youtube";
+    }
+
+    /// <summary>
+    /// YouTube credentials content.
+    /// </summary>
+    [TransloaditJsonName("content")]
+    public YoutubeCredentialsContent Content { get; set; }
+}
+
+/// <summary>
+/// Represents YouTube credentials.
+/// </summary>
+public class YoutubeCredentialsContent
+{
+    /// <summary>
+    /// YouTube OAuth access token.
+    /// </summary>
+    [TransloaditJsonName("access_token")]
+    public string AccessToken { get; set; }
+
+    /// <summary>
+    /// YouTube OAuth refresh token. Optional; used together with <see cref="AccessToken"/> for dynamic credentials.
+    /// </summary>
+    [TransloaditJsonName("refresh_token")]
+    public string RefreshToken { get; set; }
+}

--- a/tests/Transloadit.Tests/Snapshots/models.serialization.snapshot.json
+++ b/tests/Transloadit.Tests/Snapshots/models.serialization.snapshot.json
@@ -1266,6 +1266,40 @@
     ]
   },
   {
+    "type": "Transloadit.Models.Credentials.BoxCredentialsContent",
+    "properties": [
+      {
+        "name": "access_token",
+        "type": "String"
+      },
+      {
+        "name": "refresh_token",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.BoxCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "BoxCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
     "type": "Transloadit.Models.Credentials.CloudFlareCredentialsContent",
     "properties": [
       {
@@ -1491,6 +1525,48 @@
     ]
   },
   {
+    "type": "Transloadit.Models.Credentials.DropboxCredentialsContent",
+    "properties": [
+      {
+        "name": "access_token",
+        "type": "String"
+      },
+      {
+        "name": "app_key",
+        "type": "String"
+      },
+      {
+        "name": "app_secret",
+        "type": "String"
+      },
+      {
+        "name": "refresh_token",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.DropboxCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "DropboxCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
     "type": "Transloadit.Models.Credentials.FtpCredentialsContent",
     "properties": [
       {
@@ -1538,6 +1614,44 @@
       {
         "name": "content",
         "type": "Dictionary<String, String>"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.GoogleCredentialsContent",
+    "properties": [
+      {
+        "name": "bucket",
+        "type": "String"
+      },
+      {
+        "name": "key_file_contents",
+        "type": "String"
+      },
+      {
+        "name": "project_id",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.GoogleCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "GoogleCredentialsContent"
       },
       {
         "name": "name",
@@ -1920,6 +2034,40 @@
     ]
   },
   {
+    "type": "Transloadit.Models.Credentials.VimeoCredentialsContent",
+    "properties": [
+      {
+        "name": "access_token",
+        "type": "String"
+      },
+      {
+        "name": "refresh_token",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.VimeoCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "VimeoCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
     "type": "Transloadit.Models.Credentials.WasabiCredentialsContent",
     "properties": [
       {
@@ -1946,6 +2094,40 @@
       {
         "name": "content",
         "type": "WasabiCredentialsContent"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "type",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.YoutubeCredentialsContent",
+    "properties": [
+      {
+        "name": "access_token",
+        "type": "String"
+      },
+      {
+        "name": "refresh_token",
+        "type": "String"
+      }
+    ]
+  },
+  {
+    "type": "Transloadit.Models.Credentials.YoutubeCredentialsRequest",
+    "properties": [
+      {
+        "name": "auth",
+        "type": "AuthParams"
+      },
+      {
+        "name": "content",
+        "type": "YoutubeCredentialsContent"
       },
       {
         "name": "name",


### PR DESCRIPTION
## What

Adds typed Template Credentials classes for five services the library was missing. Cross-checking the docs' store/import robots against the live API showed these five credential `type`s are supported but had no typed class — users had to fall back to `GenericCredentialsRequest`.

| Type | Service | Content fields |
|------|---------|----------------|
| `google` | Google Cloud Storage | `project_id`, `key_file_contents`, `bucket` |
| `dropbox` | Dropbox (OAuth) | `app_key`, `app_secret`, `access_token`, `refresh_token` |
| `box` | Box (OAuth) | `access_token`, `refresh_token` |
| `vimeo` | Vimeo (OAuth) | `access_token`, `refresh_token` |
| `youtube` | YouTube (OAuth) | `access_token`, `refresh_token` |

## How the content fields were determined

The robot docs reference a generic credentials schema, so I probed the live API: an unknown type returns `"Invalid Credentials type"`, and a recognized type with the wrong content returns `"Invalid Credentials content. These fields must not be empty: …"` — which names the required fields. Each shape was then confirmed to create successfully (Transloadit stores a valid-shaped credential even with placeholder values).

## Tests

No new test file needed — `CredentialsSerializationSmokeTests` and the opt-in `CredentialExistenceApiTests` enumerate credential types by reflection, so they now cover all 20. Verified:
- Offline suite: **354 net8.0 / 366 net461**.
- `RUN_EXISTENCE_CHECKS=1` credential existence: **20/20 recognized** by the live API.
- Snapshot regenerated; clean build across all target frameworks (0 warnings under `TreatWarningsAsErrors`).

Note: these are OAuth/service-account credentials normally generated via the OAuth flow when creating Template Credentials; the typed classes mirror the API's content shape for dynamic/programmatic use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)