### PR TITLE
Publish to nuget.org via Trusted Publishing instead of a stored API key

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,6 +98,8 @@ jobs:
     permissions:
       contents: read
       actions: read
+      # required so GitHub issues the OIDC token that nuget.org exchanges for a short-lived API key
+      id-token: write
     steps:
       - name: Download NuGet Artifacts
         uses: actions/download-artifact@v8.0.1
@@ -108,5 +110,13 @@ jobs:
         uses: actions/setup-dotnet@v5.2.0
         with:
           dotnet-version: 10.0.x
+      # exchange the OIDC token for a temporary nuget.org API key (valid ~1 hour, single use), so no
+      # long-lived key is stored in the repository. requires a Trusted Publishing policy on nuget.org
+      # matching this repository, the deploy.yml workflow file and the Release environment.
+      - name: NuGet login (OIDC)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Publish NuGet packages to NuGet
-        run: dotnet nuget push nuget/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source "nuget.org" --skip-duplicate
+        run: dotnet nuget push nuget/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## What

The publish job authenticated with a long-lived `NUGET_KEY` secret. [Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) replaces it with a GitHub **OIDC token** that nuget.org exchanges for a **temporary API key** (valid ~1 hour, single use) — so there is no durable publishing credential stored in the repository to leak or rotate.

## Changes (`.github/workflows/deploy.yml`, publish job only)

- Grant `id-token: write` so GitHub issues the OIDC token
- Add the `NuGet/login@v1` step and push with its `NUGET_API_KEY` output
- Push to the explicit `https://api.nuget.org/v3/index.json` source

```yaml
permissions:
  contents: read
  actions: read
  id-token: write
steps:
  ...
  - name: NuGet login (OIDC)
    uses: NuGet/login@v1
    id: login
    with:
      user: ${{ secrets.NUGET_USER }}
  - name: Publish NuGet packages to NuGet
    run: dotnet nuget push nuget/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
```

## ⚠️ Required one-time setup before the next deploy

**1. Create the policy** on nuget.org → click your username → **Trusted Publishing** → add a policy:

| Field | Value |
| --- | --- |
| Repository Owner | `OleksandrOmelchenko` |
| Repository | `transloadit-sharp` |
| Workflow File | `deploy.yml` *(file name only, no `.github/workflows/` prefix)* |
| Environment | `Release` *(the publish job uses `environment: Release`)* |

**2. Add a `NUGET_USER` secret** containing your nuget.org **profile name** — not your email address.

Until the policy exists, the publish job will fail, so **keep the `NUGET_KEY` secret until a deploy succeeds**, then delete it.

Two notes from the docs worth knowing:
- The temporary key is requested immediately before the push (it expires in an hour), which is why the login step sits in the publish job rather than earlier in the pipeline.
- For **private** repositories a new policy is *temporarily* active for 7 days; it becomes permanent after the first successful publish, which supplies the immutable GitHub owner/repo IDs that protect against repo-resurrection attacks. This repo is public, so this likely doesn't apply.

Verified: workflow YAML parses, the publish job carries the three permissions, and no `NUGET_KEY` reference remains anywhere under `.github/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)